### PR TITLE
Add tracing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,6 @@ Brief description of what this PR does, and why it is needed.
 
 ### Checklist
 
-- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/granary/blob/master/CHANGELOG.md) and grouped with similar changes if possible
 - [ ] New tables and queries have appropriate indices added
 - [ ] Any new migrations have been audited to make sure they won't kill the application while being applied
 - [ ] Any new API endpoints have tests

--- a/api/src/main/resources/application.conf
+++ b/api/src/main/resources/application.conf
@@ -1,0 +1,7 @@
+tracing {
+  use-tracing = true
+  use-tracing = ${?GRANARY_USE_TRACING}
+
+  tracing-sink = jaeger
+  tracing-sink = ${?GRANARY_TRACING_SINK}
+}

--- a/api/src/main/resources/application.conf
+++ b/api/src/main/resources/application.conf
@@ -1,7 +1,4 @@
 tracing {
-  use-tracing = true
-  use-tracing = ${?GRANARY_USE_TRACING}
-
   tracing-sink = jaeger
   tracing-sink = ${?GRANARY_TRACING_SINK}
 }

--- a/api/src/main/resources/logback.xml
+++ b/api/src/main/resources/logback.xml
@@ -4,6 +4,7 @@
       <pattern>[%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n</pattern>
     </encoder>
   </appender>
+  <logger name="com.rasterfoundry.granary" level="${GRANARY_LOG_LEVEL:-INFO}"/>
   <root level="INFO">
     <appender-ref ref="STDOUT" />
   </root>

--- a/api/src/main/scala/com/rasterfoundry/granary/Config.scala
+++ b/api/src/main/scala/com/rasterfoundry/granary/Config.scala
@@ -1,0 +1,6 @@
+package com.rasterfoundry.granary.api
+
+case class TracingConfig(
+    useTracing: Boolean,
+    tracingSink: String
+)

--- a/api/src/main/scala/com/rasterfoundry/granary/Config.scala
+++ b/api/src/main/scala/com/rasterfoundry/granary/Config.scala
@@ -1,6 +1,5 @@
 package com.rasterfoundry.granary.api
 
 case class TracingConfig(
-    useTracing: Boolean,
     tracingSink: String
 )

--- a/api/src/main/scala/com/rasterfoundry/granary/HelloService.scala
+++ b/api/src/main/scala/com/rasterfoundry/granary/HelloService.scala
@@ -1,18 +1,25 @@
 package com.rasterfoundry.granary.api
 
 import cats.effect._
+import com.colisweb.tracing.TracingContextBuilder
 import io.circe._
 import org.http4s._
 import org.http4s.dsl.Http4sDsl
 import tapir.server.http4s._
 
-class HelloService(implicit contextShift: ContextShift[IO]) extends Http4sDsl[IO] {
+class HelloService(
+    implicit contextShift: ContextShift[IO],
+    contextBuilder: TracingContextBuilder[IO]
+) extends Http4sDsl[IO] {
 
-  def greet(name: String): IO[Either[HelloError, Json]] =
-    name match {
-      case "throwme" => IO.pure { Left(HelloError("Oh no an invalid input")) }
-      case s         => IO.pure { Right(Json.obj("message" -> Json.fromString(s"Hello, $s"))) }
+  def greet(name: String): IO[Either[HelloError, Json]] = {
+    contextBuilder("greet", Map("name" -> name)) use { _ =>
+      name match {
+        case "throwme" => IO.pure { Left(HelloError("Oh no an invalid input")) }
+        case s         => IO.pure { Right(Json.obj("message" -> Json.fromString(s"Hello, $s"))) }
+      }
     }
+  }
 
   val routes: HttpRoutes[IO] = HelloEndpoints.greetEndpoint.toRoutes(greet _)
 }

--- a/api/src/main/scala/com/rasterfoundry/granary/Server.scala
+++ b/api/src/main/scala/com/rasterfoundry/granary/Server.scala
@@ -23,8 +23,8 @@ object ApiServer extends IOApp with LazyLogging {
   def getApp: EitherT[IO, ConfigReaderFailures, HttpApp[IO]] =
     EitherT {
       ConfigSource.default.at("tracing").load[TracingConfig] traverse {
-        case TracingConfig(true, "JAEGER") => ???
-        case TracingConfig(true, "XRAY")   => ???
+        case TracingConfig(true, s) if s.toUpperCase() == "JAEGER" => ???
+        case TracingConfig(true, s) if s.toUpperCase() == "XRAY"  => ???
         case TracingConfig(true, s) =>
           logger.warn(s"Not a recognized tracing sink: $s. Using Jaeger")
           ???

--- a/api/src/main/scala/com/rasterfoundry/granary/Server.scala
+++ b/api/src/main/scala/com/rasterfoundry/granary/Server.scala
@@ -1,36 +1,62 @@
 package com.rasterfoundry.granary.api
 
+import cats.data.EitherT
 import cats.effect._
 import cats.implicits._
+import com.colisweb.tracing.NoOpTracingContext
+import com.typesafe.scalalogging.LazyLogging
 import org.http4s._
 import org.http4s.implicits._
 import org.http4s.server.blaze._
 import org.http4s.server.middleware._
 import org.http4s.server.Router
+import pureconfig.ConfigSource
+import pureconfig.error.ConfigReaderFailures
+import pureconfig.generic.auto._
 import tapir.openapi.OpenAPI
 import tapir.openapi.circe.yaml._
 import tapir.docs.openapi._
 import tapir.swagger.http4s.SwaggerHttp4s
 
-object ApiServer extends IOApp {
+object ApiServer extends IOApp with LazyLogging {
 
-  private val allEndpoints      = HelloEndpoints.endpoints
-  val doc: OpenAPI              = allEndpoints.toOpenAPI("Granary", "0.0.1")
-  val docRoutes: HttpRoutes[IO] = new SwaggerHttp4s(doc.toYaml).routes
-  val helloRoutes               = (new HelloService).routes
+  def getApp: EitherT[IO, ConfigReaderFailures, HttpApp[IO]] =
+    EitherT {
+      ConfigSource.default.at("tracing").load[TracingConfig] traverse {
+        case TracingConfig(true, "JAEGER") => ???
+        case TracingConfig(true, "XRAY")   => ???
+        case TracingConfig(true, s) =>
+          logger.warn(s"Not a recognized tracing sink: $s. Using Jaeger")
+          ???
+        case TracingConfig(false, _) =>
+          NoOpTracingContext.getNoOpTracingContextBuilder[IO]
+      }
+    } map { contextBuilder =>
+      implicit val tracingContextBuilder = contextBuilder
 
-  val httpApp: HttpApp[IO] = CORS(
-    Router(
-      "/api" -> (helloRoutes <+> docRoutes)
-    )
-  ).orNotFound
+      val allEndpoints              = HelloEndpoints.endpoints
+      val doc: OpenAPI              = allEndpoints.toOpenAPI("Granary", "0.0.1")
+      val docRoutes: HttpRoutes[IO] = new SwaggerHttp4s(doc.toYaml).routes
+      val helloRoutes               = (new HelloService).routes
+
+      CORS(
+        Router(
+          "/api" -> (helloRoutes <+> docRoutes)
+        )
+      ).orNotFound
+    }
 
   def run(args: List[String]): IO[ExitCode] =
-    BlazeServerBuilder[IO]
-      .bindHttp(8080, "0.0.0.0")
-      .withHttpApp(httpApp)
-      .serve
-      .compile
-      .drain
-      .as(ExitCode.Success)
+    getApp.value flatMap {
+      case Right(httpApp) =>
+        BlazeServerBuilder[IO]
+          .bindHttp(8080, "0.0.0.0")
+          .withHttpApp(httpApp)
+          .serve
+          .compile
+          .drain
+          .as(ExitCode.Success)
+      case Left(e) =>
+        IO(println(s"Failed to initialize application: $e")).as(ExitCode.Error)
+    }
 }

--- a/api/src/main/scala/com/rasterfoundry/granary/Server.scala
+++ b/api/src/main/scala/com/rasterfoundry/granary/Server.scala
@@ -17,7 +17,6 @@ import pureconfig.generic.auto._
 import tapir.openapi.circe.yaml._
 import tapir.docs.openapi._
 import tapir.swagger.http4s.SwaggerHttp4s
-import cats.effect.implicits._
 
 object ApiServer extends IOApp with LazyLogging {
 

--- a/api/src/main/scala/com/rasterfoundry/granary/Server.scala
+++ b/api/src/main/scala/com/rasterfoundry/granary/Server.scala
@@ -2,28 +2,26 @@ package com.rasterfoundry.granary.api
 
 import com.rasterfoundry.granary.api.endpoints._
 import com.rasterfoundry.granary.api.services._
-
 import cats.effect._
 import cats.implicits._
 import com.colisweb.tracing.TracingContext.TracingContextBuilder
 import com.rasterfoundry.http4s.{JaegerTracer, XRayTracer}
 import com.typesafe.scalalogging.LazyLogging
-import org.http4s._
 import org.http4s.implicits._
 import org.http4s.server.blaze._
 import org.http4s.server.middleware._
-import org.http4s.server.Router
+import org.http4s.server._
 import pureconfig.ConfigSource
 import pureconfig.error.ConfigReaderFailures
 import pureconfig.generic.auto._
-import tapir.openapi.OpenAPI
 import tapir.openapi.circe.yaml._
 import tapir.docs.openapi._
 import tapir.swagger.http4s.SwaggerHttp4s
+import cats.effect.implicits._
 
 object ApiServer extends IOApp with LazyLogging {
 
-  def getApp: Either[ConfigReaderFailures, HttpApp[IO]] =
+  def getTracingContextBuilder: Either[ConfigReaderFailures, TracingContextBuilder[IO]] =
     ConfigSource.default.at("tracing").load[TracingConfig] map {
       case TracingConfig(s) if s.toUpperCase() == "JAEGER" =>
         JaegerTracer.tracingContextBuilder
@@ -32,32 +30,31 @@ object ApiServer extends IOApp with LazyLogging {
       case TracingConfig(s) =>
         logger.warn(s"Not a recognized tracing sink: $s. Using Jaeger")
         JaegerTracer.tracingContextBuilder
-    } map { (contextBuilder: TracingContextBuilder[IO]) =>
-      implicit val tracingContextBuilder = contextBuilder
+    }
 
-      val allEndpoints              = HelloEndpoints.endpoints
-      val doc: OpenAPI              = allEndpoints.toOpenAPI("Granary", "0.0.1")
-      val docRoutes: HttpRoutes[IO] = new SwaggerHttp4s(doc.toYaml).routes
-      val helloRoutes               = (new HelloService).routes
-
-      CORS(
+  def createServer: Resource[IO, Server[IO]] =
+    for {
+      tracingContextBuilder <- Resource.liftF {
+        getTracingContextBuilder match {
+          case Left(e)        => IO.raiseError(throw new Exception(e.toString))
+          case Right(builder) => IO.pure(builder)
+        }
+      }
+      allEndpoints = HelloEndpoints.endpoints
+      docs         = allEndpoints.toOpenAPI("Granary", "0.0.1")
+      docRoutes    = new SwaggerHttp4s(docs.toYaml).routes
+      helloRoutes  = new HelloService(tracingContextBuilder).routes
+      router = CORS(
         Router(
           "/api" -> (helloRoutes <+> docRoutes)
         )
       ).orNotFound
-    }
+      server <- BlazeServerBuilder[IO]
+        .bindHttp(8080, "0.0.0.0")
+        .withHttpApp(router)
+        .resource
+    } yield server
 
   def run(args: List[String]): IO[ExitCode] =
-    getApp match {
-      case Right(httpApp) =>
-        BlazeServerBuilder[IO]
-          .bindHttp(8080, "0.0.0.0")
-          .withHttpApp(httpApp)
-          .serve
-          .compile
-          .drain
-          .as(ExitCode.Success)
-      case Left(e) =>
-        IO(println(s"Failed to initialize application: $e")).as(ExitCode.Error)
-    }
+    createServer.use(_ => IO.never).as(ExitCode.Success)
 }

--- a/api/src/main/scala/com/rasterfoundry/granary/endpoints/HelloEndpoints.scala
+++ b/api/src/main/scala/com/rasterfoundry/granary/endpoints/HelloEndpoints.scala
@@ -4,6 +4,8 @@ import io.circe._
 import tapir._
 import tapir.json.circe._
 
+import scala.language.higherKinds
+
 object HelloEndpoints {
 
   val base = endpoint.in("hello")

--- a/api/src/main/scala/com/rasterfoundry/granary/endpoints/HelloEndpoints.scala
+++ b/api/src/main/scala/com/rasterfoundry/granary/endpoints/HelloEndpoints.scala
@@ -1,4 +1,6 @@
-package com.rasterfoundry.granary.api
+package com.rasterfoundry.granary.api.endpoints
+
+import com.rasterfoundry.granary.api.error._
 
 import io.circe._
 import tapir._

--- a/api/src/main/scala/com/rasterfoundry/granary/error/HelloError.scala
+++ b/api/src/main/scala/com/rasterfoundry/granary/error/HelloError.scala
@@ -1,4 +1,4 @@
-package com.rasterfoundry.granary.api
+package com.rasterfoundry.granary.api.error
 
 import io.circe._
 import io.circe.generic.semiauto._

--- a/api/src/main/scala/com/rasterfoundry/granary/services/GranaryService.scala
+++ b/api/src/main/scala/com/rasterfoundry/granary/services/GranaryService.scala
@@ -1,0 +1,20 @@
+package com.rasterfoundry.granary.api.services
+
+import cats.effect.Resource
+import com.colisweb.tracing.TracingContext
+import com.colisweb.tracing.TracingContext.TracingContextBuilder
+
+import scala.language.higherKinds
+
+trait GranaryService {
+  // The service tag is required for Jaeger tracer to separate calls correctly
+  // It otherwise defaults to raster-foundry
+  private val baseTags: Map[String, String] = Map("service" -> "granary")
+
+  def mkContext[F[_]](
+      operationName: String,
+      tags: Map[String, String],
+      builder: TracingContextBuilder[F]
+  ): Resource[F, TracingContext[F]] =
+    builder(operationName, tags ++ baseTags)
+}

--- a/api/src/main/scala/com/rasterfoundry/granary/services/HelloService.scala
+++ b/api/src/main/scala/com/rasterfoundry/granary/services/HelloService.scala
@@ -1,7 +1,10 @@
-package com.rasterfoundry.granary.api
+package com.rasterfoundry.granary.api.services
+
+import com.rasterfoundry.granary.api.endpoints._
+import com.rasterfoundry.granary.api.error._
 
 import cats.effect._
-import com.colisweb.tracing.TracingContextBuilder
+import com.colisweb.tracing.TracingContext.TracingContextBuilder
 import io.circe._
 import org.http4s._
 import org.http4s.dsl.Http4sDsl
@@ -10,10 +13,11 @@ import tapir.server.http4s._
 class HelloService(
     implicit contextShift: ContextShift[IO],
     contextBuilder: TracingContextBuilder[IO]
-) extends Http4sDsl[IO] {
+) extends Http4sDsl[IO]
+    with GranaryService {
 
   def greet(name: String): IO[Either[HelloError, Json]] = {
-    contextBuilder("greet", Map("name" -> name)) use { _ =>
+    mkContext("greet", Map("name" -> name), contextBuilder) use { _ =>
       name match {
         case "throwme" => IO.pure { Left(HelloError("Oh no an invalid input")) }
         case s         => IO.pure { Right(Json.obj("message" -> Json.fromString(s"Hello, $s"))) }

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,13 @@ lazy val commonSettings = Seq(
     // Required by ScalaFix
     "-Yrangepos",
     "-Ywarn-unused",
-    "-Ywarn-unused-import"
+    "-Ywarn-unused-import",
+    "-deprecation",
+    "-feature"
+  ),
+  externalResolvers := Seq(
+    DefaultMavenRepository,
+    Resolver.bintrayRepo("colisweb", "maven")
   ),
   autoCompilerPlugins := true,
   addCompilerPlugin("org.spire-math"  %% "kind-projector"     % "0.9.6"),
@@ -95,11 +101,14 @@ lazy val apiDependencies = commonDependencies ++ databaseDependencies ++ Seq(
   Dependencies.http4sCirce,
   Dependencies.http4sDsl,
   Dependencies.http4sServer,
+  Dependencies.openTracing,
+  Dependencies.pureConfig,
+  // Dependencies.rasterFoundryHttp4s,
   Dependencies.tapir,
   Dependencies.tapirCirce,
   Dependencies.tapirHttp4sServer,
-  Dependencies.tapirOpenAPIDocs,
   Dependencies.tapirOpenAPICirceYAML,
+  Dependencies.tapirOpenAPIDocs,
   Dependencies.tapirSwaggerUIHttp4s
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,9 @@ lazy val commonSettings = Seq(
   ),
   externalResolvers := Seq(
     DefaultMavenRepository,
+    Resolver.sonatypeRepo("snapshots"),
+    // Required transitively
+    Resolver.bintrayRepo("guizmaii", "maven"),
     Resolver.bintrayRepo("colisweb", "maven")
   ),
   autoCompilerPlugins := true,
@@ -103,7 +106,7 @@ lazy val apiDependencies = commonDependencies ++ databaseDependencies ++ Seq(
   Dependencies.http4sServer,
   Dependencies.openTracing,
   Dependencies.pureConfig,
-  // Dependencies.rasterFoundryHttp4s,
+  Dependencies.rasterFoundryHttp4s,
   Dependencies.tapir,
   Dependencies.tapirCirce,
   Dependencies.tapirHttp4sServer,

--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,7 @@ lazy val commonSettings = Seq(
     "-Ypartial-unification",
     // Required by ScalaFix
     "-Yrangepos",
+    "-language:higherKinds",
     "-Ywarn-unused",
     "-Ywarn-unused-import",
     "-deprecation",

--- a/build.sbt
+++ b/build.sbt
@@ -105,6 +105,7 @@ lazy val apiDependencies = commonDependencies ++ databaseDependencies ++ Seq(
   Dependencies.http4sCirce,
   Dependencies.http4sDsl,
   Dependencies.http4sServer,
+  Dependencies.log4cats,
   Dependencies.openTracing,
   Dependencies.pureConfig,
   Dependencies.rasterFoundryHttp4s,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,6 @@ services:
       - POSTGRES_NAME=granary
       - POSTGRES_USER=granary
       - POSTGRES_PASSWORD=granary
-      - GRANARY_USE_TRACING=true
       - GRANARY_TRACING_SINK=jaeger
     links:
       - database:database.service.internal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
       - POSTGRES_NAME=granary
       - POSTGRES_USER=granary
       - POSTGRES_PASSWORD=granary
+      - GRANARY_USE_TRACING=true
+      - GRANARY_TRACING_SINK=jaeger
     links:
       - database:database.service.internal
       - jaeger:jaeger.service.internal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,6 @@ services:
 
   xray:
     image: amazon/aws-xray-daemon
-    env_file: .env
     volumes:
       - $HOME/.aws:/root/.aws:ro
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
       - POSTGRES_PASSWORD=granary
     links:
       - database:database.service.internal
+      - jaeger:jaeger.service.internal
+      - xray:xray.service.internal
     ports:
       - "8080:8080"
     volumes:
@@ -85,3 +87,32 @@ services:
       - database:database.service.internal
     volumes:
       - ./:/opt/granary
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.8
+    expose:
+      - 5775/udp
+      - 6831/udp
+      - 6832/udp
+      - 5778
+      - 16686
+      - 14268
+      - 9411
+    ports:
+      - 16686:16686
+    environment:
+      - COLLECTOR_ZIPKIN_HTTP_PORT=9411
+
+  xray:
+    image: amazon/aws-xray-daemon
+    env_file: .env
+    volumes:
+      - $HOME/.aws:/root/.aws:ro
+    ports:
+      - 2000
+    entrypoint: "/usr/bin/xray"
+    command:
+      - "-t"
+      - "0.0.0.0:2000"
+      - "-b"
+      - "0.0.0.0:2000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
     environment:
       - AWS_PROFILE
       - ENVIRONMENT=development
+      - GRANARY_LOG_LEVEL=DEBUG
       - POSTGRES_URL=jdbc:postgresql://database.service.internal/
       - POSTGRES_NAME=granary
       - POSTGRES_USER=granary

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,30 +4,34 @@ import sbt._
 
 // Versions
 object Versions {
-  val CirceVersion         = "0.12.1"
-  val DoobieVersion        = "0.8.2"
-  val Http4sVersion        = "0.20.11"
-  val LogbackVersion       = "1.2.3"
-  val RasterFoundryVersion = "1.31.0"
-  val ScapegoatVersion     = "1.3.8"
-  val Specs2Version        = "4.1.0"
-  val TapirVersion         = "0.11.6"
+  val CirceVersion       = "0.12.1"
+  val DoobieVersion      = "0.8.2"
+  val Http4sVersion      = "0.20.11"
+  val LogbackVersion     = "1.2.3"
+  val OpenTracingVersion = "0.1.0"
+  val PureConfig         = "0.12.1"
+  // val RasterFoundryVersion = "1.31.0"
+  val ScapegoatVersion = "1.3.8"
+  val Specs2Version    = "4.1.0"
+  val TapirVersion     = "0.11.6"
 }
 
 object Dependencies {
-  val circeCore             = "io.circe"               %% "circe-core"               % Versions.CirceVersion
-  val circeGeneric          = "io.circe"               %% "circe-generic"            % Versions.CirceVersion
-  val doobie                = "org.tpolecat"           %% "doobie-core"              % Versions.DoobieVersion
-  val doobieHikari          = "org.tpolecat"           %% "doobie-hikari"            % Versions.DoobieVersion
-  val doobiePostgres        = "org.tpolecat"           %% "doobie-postgres"          % Versions.DoobieVersion
-  val doobieScalatest       = "org.tpolecat"           %% "doobie-scalatest"         % Versions.DoobieVersion % "test"
-  val doobieSpecs2          = "org.tpolecat"           %% "doobie-specs2"            % Versions.DoobieVersion % "test"
-  val http4s                = "org.http4s"             %% "http4s-blaze-server"      % Versions.Http4sVersion
-  val http4sCirce           = "org.http4s"             %% "http4s-circe"             % Versions.Http4sVersion
-  val http4sDsl             = "org.http4s"             %% "http4s-dsl"               % Versions.Http4sVersion
-  val http4sServer          = "org.http4s"             %% "http4s-blaze-server"      % Versions.Http4sVersion
-  val logbackClassic        = "ch.qos.logback"         % "logback-classic"           % Versions.LogbackVersion
-  val rasterfoundryHttp4s   = "com.rasterfoundry"      %% "http4s-util"              % Versions.RasterFoundryVersion
+  val circeCore       = "io.circe"              %% "circe-core"          % Versions.CirceVersion
+  val circeGeneric    = "io.circe"              %% "circe-generic"       % Versions.CirceVersion
+  val doobie          = "org.tpolecat"          %% "doobie-core"         % Versions.DoobieVersion
+  val doobieHikari    = "org.tpolecat"          %% "doobie-hikari"       % Versions.DoobieVersion
+  val doobiePostgres  = "org.tpolecat"          %% "doobie-postgres"     % Versions.DoobieVersion
+  val doobieScalatest = "org.tpolecat"          %% "doobie-scalatest"    % Versions.DoobieVersion % "test"
+  val doobieSpecs2    = "org.tpolecat"          %% "doobie-specs2"       % Versions.DoobieVersion % "test"
+  val http4s          = "org.http4s"            %% "http4s-blaze-server" % Versions.Http4sVersion
+  val http4sCirce     = "org.http4s"            %% "http4s-circe"        % Versions.Http4sVersion
+  val http4sDsl       = "org.http4s"            %% "http4s-dsl"          % Versions.Http4sVersion
+  val http4sServer    = "org.http4s"            %% "http4s-blaze-server" % Versions.Http4sVersion
+  val logbackClassic  = "ch.qos.logback"        % "logback-classic"      % Versions.LogbackVersion
+  val openTracing     = "com.colisweb"          %% "scala-opentracing"   % Versions.OpenTracingVersion
+  val pureConfig      = "com.github.pureconfig" %% "pureconfig"          % Versions.PureConfig
+  // val rasterFoundryHttp4s   = "com.rasterfoundry"      %% "http4s-util"              % Versions.RasterFoundryVersion
   val specs2Core            = "org.specs2"             %% "specs2-core"              % Versions.Specs2Version % "test"
   val tapir                 = "com.softwaremill.tapir" %% "tapir-core"               % Versions.TapirVersion
   val tapirCirce            = "com.softwaremill.tapir" %% "tapir-json-circe"         % Versions.TapirVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,6 +8,7 @@ object Versions {
   val DoobieVersion        = "0.8.2"
   val Http4sVersion        = "0.20.11"
   val LogbackVersion       = "1.2.3"
+  val Log4CatsVersion      = "1.0.1"
   val OpenTracingVersion   = "0.0.6"
   val PureConfig           = "0.12.1"
   val RasterFoundryVersion = "1.31.0-11-g486496c-SNAPSHOT"
@@ -29,6 +30,7 @@ object Dependencies {
   val http4sDsl             = "org.http4s"             %% "http4s-dsl"               % Versions.Http4sVersion
   val http4sServer          = "org.http4s"             %% "http4s-blaze-server"      % Versions.Http4sVersion
   val logbackClassic        = "ch.qos.logback"         % "logback-classic"           % Versions.LogbackVersion
+  val log4cats              = "io.chrisdavenport" %% "log4cats-slf4j" % Versions.Log4CatsVersion
   val openTracing           = "com.colisweb"           %% "scala-opentracing"        % Versions.OpenTracingVersion
   val pureConfig            = "com.github.pureconfig"  %% "pureconfig"               % Versions.PureConfig
   val rasterFoundryHttp4s   = "com.rasterfoundry"      %% "http4s-util"              % Versions.RasterFoundryVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,13 +4,14 @@ import sbt._
 
 // Versions
 object Versions {
-  val Http4sVersion    = "0.20.11"
-  val Specs2Version    = "4.1.0"
-  val LogbackVersion   = "1.2.3"
-  val ScapegoatVersion = "1.3.8"
-  val CirceVersion     = "0.12.1"
-  val DoobieVersion    = "0.8.2"
-  val TapirVersion     = "0.11.6"
+  val CirceVersion         = "0.12.1"
+  val DoobieVersion        = "0.8.2"
+  val Http4sVersion        = "0.20.11"
+  val LogbackVersion       = "1.2.3"
+  val RasterFoundryVersion = "1.31.0"
+  val ScapegoatVersion     = "1.3.8"
+  val Specs2Version        = "4.1.0"
+  val TapirVersion         = "0.11.6"
 }
 
 object Dependencies {
@@ -19,18 +20,19 @@ object Dependencies {
   val doobie                = "org.tpolecat"           %% "doobie-core"              % Versions.DoobieVersion
   val doobieHikari          = "org.tpolecat"           %% "doobie-hikari"            % Versions.DoobieVersion
   val doobiePostgres        = "org.tpolecat"           %% "doobie-postgres"          % Versions.DoobieVersion
-  val doobieSpecs2          = "org.tpolecat"           %% "doobie-specs2"            % Versions.DoobieVersion % "test"
   val doobieScalatest       = "org.tpolecat"           %% "doobie-scalatest"         % Versions.DoobieVersion % "test"
+  val doobieSpecs2          = "org.tpolecat"           %% "doobie-specs2"            % Versions.DoobieVersion % "test"
   val http4s                = "org.http4s"             %% "http4s-blaze-server"      % Versions.Http4sVersion
   val http4sCirce           = "org.http4s"             %% "http4s-circe"             % Versions.Http4sVersion
-  val http4sServer          = "org.http4s"             %% "http4s-blaze-server"      % Versions.Http4sVersion
   val http4sDsl             = "org.http4s"             %% "http4s-dsl"               % Versions.Http4sVersion
+  val http4sServer          = "org.http4s"             %% "http4s-blaze-server"      % Versions.Http4sVersion
   val logbackClassic        = "ch.qos.logback"         % "logback-classic"           % Versions.LogbackVersion
+  val rasterfoundryHttp4s   = "com.rasterfoundry"      %% "http4s-util"              % Versions.RasterFoundryVersion
   val specs2Core            = "org.specs2"             %% "specs2-core"              % Versions.Specs2Version % "test"
   val tapir                 = "com.softwaremill.tapir" %% "tapir-core"               % Versions.TapirVersion
   val tapirCirce            = "com.softwaremill.tapir" %% "tapir-json-circe"         % Versions.TapirVersion
   val tapirHttp4sServer     = "com.softwaremill.tapir" %% "tapir-http4s-server"      % Versions.TapirVersion
-  val tapirOpenAPIDocs      = "com.softwaremill.tapir" %% "tapir-openapi-docs"       % Versions.TapirVersion
   val tapirOpenAPICirceYAML = "com.softwaremill.tapir" %% "tapir-openapi-circe-yaml" % Versions.TapirVersion
+  val tapirOpenAPIDocs      = "com.softwaremill.tapir" %% "tapir-openapi-docs"       % Versions.TapirVersion
   val tapirSwaggerUIHttp4s  = "com.softwaremill.tapir" %% "tapir-swagger-ui-http4s"  % Versions.TapirVersion
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,33 +4,33 @@ import sbt._
 
 // Versions
 object Versions {
-  val CirceVersion       = "0.12.1"
-  val DoobieVersion      = "0.8.2"
-  val Http4sVersion      = "0.20.11"
-  val LogbackVersion     = "1.2.3"
-  val OpenTracingVersion = "0.0.7"
-  val PureConfig         = "0.12.1"
+  val CirceVersion         = "0.12.1"
+  val DoobieVersion        = "0.8.2"
+  val Http4sVersion        = "0.20.11"
+  val LogbackVersion       = "1.2.3"
+  val OpenTracingVersion   = "0.0.6"
+  val PureConfig           = "0.12.1"
   val RasterFoundryVersion = "1.31.0-11-g486496c-SNAPSHOT"
-  val ScapegoatVersion = "1.3.8"
-  val Specs2Version    = "4.1.0"
-  val TapirVersion     = "0.11.6"
+  val ScapegoatVersion     = "1.3.8"
+  val Specs2Version        = "4.1.0"
+  val TapirVersion         = "0.11.6"
 }
 
 object Dependencies {
-  val circeCore       = "io.circe"              %% "circe-core"          % Versions.CirceVersion
-  val circeGeneric    = "io.circe"              %% "circe-generic"       % Versions.CirceVersion
-  val doobie          = "org.tpolecat"          %% "doobie-core"         % Versions.DoobieVersion
-  val doobieHikari    = "org.tpolecat"          %% "doobie-hikari"       % Versions.DoobieVersion
-  val doobiePostgres  = "org.tpolecat"          %% "doobie-postgres"     % Versions.DoobieVersion
-  val doobieScalatest = "org.tpolecat"          %% "doobie-scalatest"    % Versions.DoobieVersion % "test"
-  val doobieSpecs2    = "org.tpolecat"          %% "doobie-specs2"       % Versions.DoobieVersion % "test"
-  val http4s          = "org.http4s"            %% "http4s-blaze-server" % Versions.Http4sVersion
-  val http4sCirce     = "org.http4s"            %% "http4s-circe"        % Versions.Http4sVersion
-  val http4sDsl       = "org.http4s"            %% "http4s-dsl"          % Versions.Http4sVersion
-  val http4sServer    = "org.http4s"            %% "http4s-blaze-server" % Versions.Http4sVersion
-  val logbackClassic  = "ch.qos.logback"        % "logback-classic"      % Versions.LogbackVersion
-  val openTracing     = "com.colisweb"          %% "scala-opentracing"   % Versions.OpenTracingVersion
-  val pureConfig      = "com.github.pureconfig" %% "pureconfig"          % Versions.PureConfig
+  val circeCore             = "io.circe"               %% "circe-core"               % Versions.CirceVersion
+  val circeGeneric          = "io.circe"               %% "circe-generic"            % Versions.CirceVersion
+  val doobie                = "org.tpolecat"           %% "doobie-core"              % Versions.DoobieVersion
+  val doobieHikari          = "org.tpolecat"           %% "doobie-hikari"            % Versions.DoobieVersion
+  val doobiePostgres        = "org.tpolecat"           %% "doobie-postgres"          % Versions.DoobieVersion
+  val doobieScalatest       = "org.tpolecat"           %% "doobie-scalatest"         % Versions.DoobieVersion % "test"
+  val doobieSpecs2          = "org.tpolecat"           %% "doobie-specs2"            % Versions.DoobieVersion % "test"
+  val http4s                = "org.http4s"             %% "http4s-blaze-server"      % Versions.Http4sVersion
+  val http4sCirce           = "org.http4s"             %% "http4s-circe"             % Versions.Http4sVersion
+  val http4sDsl             = "org.http4s"             %% "http4s-dsl"               % Versions.Http4sVersion
+  val http4sServer          = "org.http4s"             %% "http4s-blaze-server"      % Versions.Http4sVersion
+  val logbackClassic        = "ch.qos.logback"         % "logback-classic"           % Versions.LogbackVersion
+  val openTracing           = "com.colisweb"           %% "scala-opentracing"        % Versions.OpenTracingVersion
+  val pureConfig            = "com.github.pureconfig"  %% "pureconfig"               % Versions.PureConfig
   val rasterFoundryHttp4s   = "com.rasterfoundry"      %% "http4s-util"              % Versions.RasterFoundryVersion
   val specs2Core            = "org.specs2"             %% "specs2-core"              % Versions.Specs2Version % "test"
   val tapir                 = "com.softwaremill.tapir" %% "tapir-core"               % Versions.TapirVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,9 +8,9 @@ object Versions {
   val DoobieVersion      = "0.8.2"
   val Http4sVersion      = "0.20.11"
   val LogbackVersion     = "1.2.3"
-  val OpenTracingVersion = "0.1.0"
+  val OpenTracingVersion = "0.0.7"
   val PureConfig         = "0.12.1"
-  // val RasterFoundryVersion = "1.31.0"
+  val RasterFoundryVersion = "1.31.0-11-g486496c-SNAPSHOT"
   val ScapegoatVersion = "1.3.8"
   val Specs2Version    = "4.1.0"
   val TapirVersion     = "0.11.6"
@@ -31,7 +31,7 @@ object Dependencies {
   val logbackClassic  = "ch.qos.logback"        % "logback-classic"      % Versions.LogbackVersion
   val openTracing     = "com.colisweb"          %% "scala-opentracing"   % Versions.OpenTracingVersion
   val pureConfig      = "com.github.pureconfig" %% "pureconfig"          % Versions.PureConfig
-  // val rasterFoundryHttp4s   = "com.rasterfoundry"      %% "http4s-util"              % Versions.RasterFoundryVersion
+  val rasterFoundryHttp4s   = "com.rasterfoundry"      %% "http4s-util"              % Versions.RasterFoundryVersion
   val specs2Core            = "org.specs2"             %% "specs2-core"              % Versions.Specs2Version % "test"
   val tapir                 = "com.softwaremill.tapir" %% "tapir-core"               % Versions.TapirVersion
   val tapirCirce            = "com.softwaremill.tapir" %% "tapir-json-circe"         % Versions.TapirVersion


### PR DESCRIPTION
## Overview

This PR wires up work done in Raster Foundry's `http4s-util` subproject to add tracing to the one existing service. Tracing can be configured to point to xray or jaeger currently, but xray doesn't work for a confusing reason (probably because the http4s/circe/etc. versions bump to cats 2.0, see more in notes). 

### Notes

The broken XRayTracer I think has to do with binary compatibility, but I'm not sure what's causing it in particular. An obvious guess was that since http4s is behind doobie and circe on cats-2.0 upgrades, I'd just need to download everything else, but I get the same error with doobie 0.7 and circe 0.11 as I do with doobie 0.8 and circe 0.12:

```
java.lang.NoSuchMethodError: 'java.lang.String io.circe.Printer$.apply$default$18()'
    at com.rasterfoundry.http4s.xray.UdpClient$.<init>(UdpClient.scala:11)
    at com.rasterfoundry.http4s.xray.UdpClient$.<clinit>(UdpClient.scala)
    at com.rasterfoundry.http4s.xray.XRayTracingContext$.$anonfun$resource$4(XRayTracingContext.scala:92)
    at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:139)
    at cats.effect.internals.IORunLoop$.start(IORunLoop.scala:34)
    at cats.effect.internals.IOBracket$.$anonfun$apply$1(IOBracket.scala:44)
    at cats.effect.internals.IOBracket$.$anonfun$apply$1$adapted(IOBracket.scala:34)
    at cats.effect.internals.IORunLoop$RestartCallback.start(IORunLoop.scala:341)
    at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:119)
    at cats.effect.internals.IORunLoop$RestartCallback.signal(IORunLoop.scala:355)
    at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:376)
    at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:316)
    at cats.effect.internals.IOShift$Tick.run(IOShift.scala:36)
    at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
    at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
    at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
    at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
    at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
    at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177)
```

## Testing Instructions

- `api/assembly`
- bring up server
- make some requests to `/api/hello/<name>`
- look at requests under the `granary` service in Jaeger on 16686
- change your GRANARY_LOG_LEVEL in docker-compose to INFO
- restart the server
- confirm you don't get a DEBUG message about the jaeger tracing being used

Closes #18 
