### PR TITLE
Disable CircleCI docker_layer_caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,6 @@ jobs:
     steps:
       - checkout
 
-      # https://circleci.com/docs/2.0/building-docker-images/
-      - setup_remote_docker:
-          docker_layer_caching: true
-
       - restore_cache:
           keys:
             - sbt-cache-{{ checksum "project/Dependencies.scala" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,10 @@ jobs:
     steps:
       - checkout
 
+      # https://circleci.com/docs/2.0/building-docker-images/
+      - setup_remote_docker:
+          docker_layer_caching: false
+
       - restore_cache:
           keys:
             - sbt-cache-{{ checksum "project/Dependencies.scala" }}


### PR DESCRIPTION
## Overview

The `docker_layer_caching` feature appears to have a free tier of some kind that we've exhausted. Disabling the feature in our project configuration prevents builds from failing execute immediately.

### Checklist

~- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/granary/blob/master/CHANGELOG.md) and grouped with similar changes if possible~
~- [ ] New tables and queries have appropriate indices added~
~- [ ] Any new migrations have been audited to make sure they won't kill the application while being applied~
~- [ ] Any new API endpoints have tests~
~- [ ] Any frontend changes are hidden behind a feature flag~

## Testing Instructions

Inspect the output of https://app.circleci.com/jobs/github/raster-foundry/granary/61.