### PR TITLE
Add single-use prediction update webhooks

### DIFF
--- a/api/src/main/scala/com/rasterfoundry/granary/endpoints/PredictionEndpoints.scala
+++ b/api/src/main/scala/com/rasterfoundry/granary/endpoints/PredictionEndpoints.scala
@@ -47,11 +47,7 @@ object PredictionEndpoints {
       .out(jsonBody[Prediction])
       .errorOut(
         oneOf[CrudError](
-          statusMapping(404, jsonBody[NotFound].description("not found")),
-          statusMapping(
-            409,
-            jsonBody[Conflict].description("prediction update webhook already used")
-          )
+          statusMapping(404, jsonBody[NotFound].description("not found"))
         )
       )
 

--- a/api/src/main/scala/com/rasterfoundry/granary/endpoints/PredictionEndpoints.scala
+++ b/api/src/main/scala/com/rasterfoundry/granary/endpoints/PredictionEndpoints.scala
@@ -38,5 +38,22 @@ object PredictionEndpoints {
       .in(query[Option[JobStatus]]("status"))
       .out(jsonBody[List[Prediction]])
 
-  val endpoints = List(idLookup, create, list)
+  val addResults =
+    base.post
+      .in(path[UUID])
+      .in("results")
+      .in(path[UUID])
+      .in(jsonBody[PredictionStatusUpdate])
+      .out(jsonBody[Prediction])
+      .errorOut(
+        oneOf[CrudError](
+          statusMapping(404, jsonBody[NotFound].description("not found")),
+          statusMapping(
+            409,
+            jsonBody[Conflict].description("prediction update webhook already used")
+          )
+        )
+      )
+
+  val endpoints = List(idLookup, create, list, addResults)
 }

--- a/api/src/main/scala/com/rasterfoundry/granary/error/CrudError.scala
+++ b/api/src/main/scala/com/rasterfoundry/granary/error/CrudError.scala
@@ -8,13 +8,16 @@ import io.circe.syntax._
 sealed abstract class CrudError
 
 object CrudError {
+
   implicit val decCrudErrror
     : Decoder[CrudError] = Decoder[NotFound].widen or Decoder[ValidationError].widen
+
   implicit val encCrudError: Encoder[CrudError] = new Encoder[CrudError] {
 
     def apply(thing: CrudError): Json = thing match {
       case t: NotFound        => t.asJson
       case t: ValidationError => t.asJson
+      case t: Conflict        => t.asJson
     }
   }
 }
@@ -31,4 +34,11 @@ case class ValidationError(msg: String) extends CrudError
 object ValidationError {
   implicit val encValidationError: Encoder[ValidationError] = deriveEncoder
   implicit val decValidationError: Decoder[ValidationError] = deriveDecoder
+}
+
+case class Conflict(msg: String) extends CrudError
+
+object Conflict {
+  implicit val encConflict: Encoder[Conflict] = deriveEncoder
+  implicit val decConflict: Decoder[Conflict] = deriveDecoder
 }

--- a/api/src/main/scala/com/rasterfoundry/granary/error/CrudError.scala
+++ b/api/src/main/scala/com/rasterfoundry/granary/error/CrudError.scala
@@ -17,7 +17,6 @@ object CrudError {
     def apply(thing: CrudError): Json = thing match {
       case t: NotFound        => t.asJson
       case t: ValidationError => t.asJson
-      case t: Conflict        => t.asJson
     }
   }
 }
@@ -34,11 +33,4 @@ case class ValidationError(msg: String) extends CrudError
 object ValidationError {
   implicit val encValidationError: Encoder[ValidationError] = deriveEncoder
   implicit val decValidationError: Decoder[ValidationError] = deriveDecoder
-}
-
-case class Conflict(msg: String) extends CrudError
-
-object Conflict {
-  implicit val encConflict: Encoder[Conflict] = deriveEncoder
-  implicit val decConflict: Decoder[Conflict] = deriveDecoder
 }

--- a/api/src/main/scala/com/rasterfoundry/granary/services/PredictionService.scala
+++ b/api/src/main/scala/com/rasterfoundry/granary/services/PredictionService.scala
@@ -48,12 +48,6 @@ class PredictionService[F[_]: Sync](contextBuilder: TracingContextBuilder[F], xa
           Left(
             ValidationError(errs map { _.getMessage } reduce)
           )
-        case Left(PredictionDao.WebhookAlreadyUsed) =>
-          Left(
-            ValidationError(
-              "Webhook check somehow invoked in create endpoint. Something is very wrong"
-            )
-          )
       })
     }
 
@@ -75,11 +69,7 @@ class PredictionService[F[_]: Sync](contextBuilder: TracingContextBuilder[F], xa
       )({
         case None =>
           Left(NotFound())
-        case Some(Left(PredictionDao.WebhookAlreadyUsed)) =>
-          Left(
-            Conflict(s"Webhook $predictionWebhookId for prediction $predictionId was already used")
-          )
-        case Some(Right(p)) =>
+        case Some(p) =>
           Right(p)
       })
     }

--- a/api/src/main/scala/com/rasterfoundry/granary/services/PredictionService.scala
+++ b/api/src/main/scala/com/rasterfoundry/granary/services/PredictionService.scala
@@ -50,10 +50,18 @@ class PredictionService[F[_]: Sync](contextBuilder: TracingContextBuilder[F], xa
       })
     }
 
-  val list   = PredictionEndpoints.list.toRoutes(Function.tupled(listPredictions))
-  val detail = PredictionEndpoints.idLookup.toRoutes(getById)
-  val create = PredictionEndpoints.create.toRoutes(createPrediction)
+  def addPredictionResults(
+      predictionId: UUID,
+      predictionWebhookId: UUID,
+      updateMessage: PredictionStatusUpdate
+  ): F[Either[CrudError, Prediction]] =
+    ???
 
-  val routes: HttpRoutes[F] = detail <+> create <+> list
+  val list       = PredictionEndpoints.list.toRoutes(Function.tupled(listPredictions))
+  val detail     = PredictionEndpoints.idLookup.toRoutes(getById)
+  val create     = PredictionEndpoints.create.toRoutes(createPrediction)
+  val addResults = PredictionEndpoints.addResults.toRoutes(Function.tupled(addPredictionResults))
+
+  val routes: HttpRoutes[F] = detail <+> create <+> list <+> addResults
 
 }

--- a/database/src/main/resources/migrations/V5__add_prediction_webhooks.sql
+++ b/database/src/main/resources/migrations/V5__add_prediction_webhooks.sql
@@ -1,0 +1,2 @@
+ALTER TABLE predictions ADD COLUMN output_location text;
+ALTER TABLE predictions ADD COLUMN webhook_id uuid;

--- a/database/src/main/scala/com/rasterfoundry/granary/PredictionDao.scala
+++ b/database/src/main/scala/com/rasterfoundry/granary/PredictionDao.scala
@@ -17,7 +17,6 @@ object PredictionDao {
 
   sealed abstract class PredictionDaoError extends Throwable
   case object ModelNotFound                extends PredictionDaoError
-  case object WebhookAlreadyUsed           extends PredictionDaoError
 
   case class ArgumentsValidationFailed(underlying: NonEmptyList[ValidationError])
       extends PredictionDaoError
@@ -89,7 +88,7 @@ object PredictionDao {
       predictionId: UUID,
       webhookId: UUID,
       status: PredictionStatusUpdate
-  ): OptionT[ConnectionIO, Either[WebhookAlreadyUsed.type, Prediction]] =
+  ): OptionT[ConnectionIO, Prediction] =
     for {
       existingPrediction <- OptionT(getPrediction(predictionId)) flatMap {
         case pred if pred.webhookId == Some(webhookId) => OptionT.some(pred)
@@ -129,6 +128,6 @@ object PredictionDao {
           "output_location",
           "webhook_id"
         )
-      } map { Right(_) }
+      }
     } yield update
 }

--- a/database/src/main/scala/com/rasterfoundry/granary/PredictionDao.scala
+++ b/database/src/main/scala/com/rasterfoundry/granary/PredictionDao.scala
@@ -17,6 +17,7 @@ object PredictionDao {
 
   sealed abstract class PredictionDaoError extends Throwable
   case object ModelNotFound                extends PredictionDaoError
+  case object WebhookAlreadyUsed           extends PredictionDaoError
 
   case class ArgumentsValidationFailed(underlying: NonEmptyList[ValidationError])
       extends PredictionDaoError
@@ -84,8 +85,10 @@ object PredictionDao {
     }
   }
 
-  def update(predictionId: UUID,
-             webhookId: UUID,
-             status: PredictionStatusUpdate): ConnectionIO[Either[PredictionDaoError, Unit]] =
+  def addResults(
+      predictionId: UUID,
+      webhookId: UUID,
+      status: PredictionStatusUpdate
+  ): OptionT[ConnectionIO, Either[WebhookAlreadyUsed.type, Prediction]] =
     ???
 }

--- a/database/src/main/scala/com/rasterfoundry/granary/PredictionDao.scala
+++ b/database/src/main/scala/com/rasterfoundry/granary/PredictionDao.scala
@@ -22,7 +22,12 @@ object PredictionDao {
       extends PredictionDaoError
 
   val selectF =
-    fr"select id, model_id, invoked_at, arguments, status, status_reason FROM predictions"
+    fr"""
+      SELECT
+        id, model_id, invoked_at, arguments, status,
+        status_reason, output_location, webhook_id
+      FROM predictions
+    """
 
   def listPredictions(
       modelId: Option[UUID],
@@ -47,9 +52,10 @@ object PredictionDao {
   ): ConnectionIO[Either[PredictionDaoError, Prediction]] = {
     val fragment = fr"""
       INSERT INTO predictions
-        (id, model_id, invoked_at, arguments, status, status_reason)
+        (id, model_id, invoked_at, arguments, status, status_reason, output_location, webhook_id)
       VALUES
-        (uuid_generate_v4(), ${prediction.modelId}, now(), ${prediction.arguments}, 'CREATED', NULL)
+        (uuid_generate_v4(), ${prediction.modelId}, now(), ${prediction.arguments},
+        'CREATED', NULL, NULL, uuid_generate_v4())
     """
     val insertIO: OptionT[ConnectionIO, Either[PredictionDaoError, Prediction]] = for {
       model <- OptionT { ModelDao.getModel(prediction.modelId) }
@@ -64,7 +70,9 @@ object PredictionDao {
               "invoked_at",
               "arguments",
               "status",
-              "status_reason"
+              "status_reason",
+              "output_location",
+              "webhook_id"
             ) map { Right(_) }
         }
       }
@@ -75,4 +83,9 @@ object PredictionDao {
       case None      => Left(ModelNotFound)
     }
   }
+
+  def update(predictionId: UUID,
+             webhookId: UUID,
+             status: PredictionStatusUpdate): ConnectionIO[Either[PredictionDaoError, Unit]] =
+    ???
 }

--- a/datamodel/src/main/scala/com/rasterfoundry/granary/Prediction.scala
+++ b/datamodel/src/main/scala/com/rasterfoundry/granary/Prediction.scala
@@ -13,7 +13,8 @@ case class Prediction(
     arguments: Json,
     status: JobStatus,
     statusReason: Option[String],
-    outputLocation: Option[String]
+    outputLocation: Option[String],
+    webhookId: Option[UUID]
 )
 
 object Prediction {

--- a/datamodel/src/main/scala/com/rasterfoundry/granary/Prediction.scala
+++ b/datamodel/src/main/scala/com/rasterfoundry/granary/Prediction.scala
@@ -12,7 +12,8 @@ case class Prediction(
     invokedAt: Instant,
     arguments: Json,
     status: JobStatus,
-    statusReason: Option[String]
+    statusReason: Option[String],
+    outputLocation: Option[String]
 )
 
 object Prediction {

--- a/datamodel/src/main/scala/com/rasterfoundry/granary/PredictionStatusUpdate.scala
+++ b/datamodel/src/main/scala/com/rasterfoundry/granary/PredictionStatusUpdate.scala
@@ -1,0 +1,41 @@
+package com.rasterfoundry.granary.datamodel
+
+import cats.implicits._
+import io.circe._
+import io.circe.generic.semiauto._
+
+sealed abstract class PredictionStatusUpdate
+
+object PredictionStatusUpdate {
+
+  implicit val decStatusUpdate
+      : Decoder[PredictionStatusUpdate] = Decoder[PredictionFailure].widen or Decoder[
+    PredictionSuccess
+  ].widen
+
+  implicit val encStatusUpdate: Encoder[PredictionStatus] = new Encoder[PredictionStatus] {
+
+    def apply(t: Thing): Json = t match {
+      case ps: PredictionFailure => ps.asJson
+      case ps: PredictionSuccess => ps.asJson
+    }
+  }
+}
+
+case class PredictionFailure(
+    message: String
+) extends PredictionStatusUpdate
+
+object PredictionFailure {
+  implicit val encPredictionFailure: Encoder[PredictionFailure] = deriveEncoder
+  implicit val decPredictionFailure: Decoder[PredictionFailure] = deriveDecoder
+}
+
+case class PredictionSuccess(
+    outputLocation: String
+) extends PredictionStatusUpdate
+
+object PredictionSuccess {
+  implicit val encPredictionSuccess: Encoder[PredictionSuccess] = deriveEncoder
+  implicit val decPredictionSuccess: Decoder[PredictionSuccess] = deriveDecoder
+}

--- a/datamodel/src/main/scala/com/rasterfoundry/granary/PredictionStatusUpdate.scala
+++ b/datamodel/src/main/scala/com/rasterfoundry/granary/PredictionStatusUpdate.scala
@@ -3,23 +3,25 @@ package com.rasterfoundry.granary.datamodel
 import cats.implicits._
 import io.circe._
 import io.circe.generic.semiauto._
+import io.circe.syntax._
 
 sealed abstract class PredictionStatusUpdate
 
 object PredictionStatusUpdate {
 
   implicit val decStatusUpdate
-      : Decoder[PredictionStatusUpdate] = Decoder[PredictionFailure].widen or Decoder[
+    : Decoder[PredictionStatusUpdate] = Decoder[PredictionFailure].widen or Decoder[
     PredictionSuccess
   ].widen
 
-  implicit val encStatusUpdate: Encoder[PredictionStatus] = new Encoder[PredictionStatus] {
+  implicit val encStatusUpdate: Encoder[PredictionStatusUpdate] =
+    new Encoder[PredictionStatusUpdate] {
 
-    def apply(t: Thing): Json = t match {
-      case ps: PredictionFailure => ps.asJson
-      case ps: PredictionSuccess => ps.asJson
+      def apply(t: PredictionStatusUpdate): Json = t match {
+        case ps: PredictionFailure => ps.asJson
+        case ps: PredictionSuccess => ps.asJson
+      }
     }
-  }
 }
 
 case class PredictionFailure(


### PR DESCRIPTION
## Overview

This PR creates a webhook off of `/predictions/<id>/results/<webhookid>` that can be POSTed to _once_. It creates the id for the webhook when the prediction is created, and removes it from the prediction record as soon as it's updated.

### Checklist

- ~New tables and queries have appropriate indices added~
- [x] Any new migrations have been audited to make sure they won't kill the application while being applied
- [x] Any new API endpoints have tests

### Notes

I made two choices here that I don't love, but where I love the alternatives worse. I had initially attempted to track whether the webhook is missing because it's been used or because the prediction is missing or the webhook id is wrong for the prediction. That would I think require a separate table for webhooks. I didn't really want to add a table for prediction webhooks with just `id, prediction_id, used`, since it seemed like a bit of overhead for minimal gain. Moreover, `webhook_id = null` pretty clearly maps to "you can't update this anymore," so I don't think we lose much clarity.

## Testing Instructions

- run tests

Closes #14 
