### PR TITLE
Include webhook url with job kickoff arguments

### DIFF
--- a/api/src/main/resources/application.conf
+++ b/api/src/main/resources/application.conf
@@ -7,3 +7,7 @@ s3 {
   data-bucket = rasterfoundry-development-data-us-east-1
   data-bucket = ${?GRANARY_DATA_BUCKET}
 }
+
+meta {
+  api-host = ${?GRANARY_API_HOST}
+}

--- a/api/src/main/scala/com/rasterfoundry/granary/Config.scala
+++ b/api/src/main/scala/com/rasterfoundry/granary/Config.scala
@@ -5,3 +5,5 @@ case class TracingConfig(
 )
 
 case class S3Config(dataBucket: String)
+
+case class MetaConfig(apiHost: String)

--- a/api/src/test/scala/com/rasterfoundry/granary/PredictionServiceSpec.scala
+++ b/api/src/test/scala/com/rasterfoundry/granary/PredictionServiceSpec.scala
@@ -43,7 +43,12 @@ class PredictionServiceSpec
     new ModelService[IO](tracingContextBuilder, transactor)
 
   val predictionService =
-    new PredictionService[IO](tracingContextBuilder, transactor, dataBucket)
+    new PredictionService[IO](
+      tracingContextBuilder,
+      transactor,
+      dataBucket,
+      "http://localhost:8080/api"
+    )
 
   def updatePredictionRaw(
       message: PredictionStatusUpdate,

--- a/deployment/terraform/api.tf
+++ b/deployment/terraform/api.tf
@@ -109,6 +109,8 @@ resource "aws_ecs_task_definition" "api" {
   container_definitions = templatefile("${path.module}/task-definitions/api.json.tmpl", {
     image = "quay.io/raster-foundry/granary-api:${var.image_tag}"
 
+    api_host = "https://${var.r53_public_hosted_zone_record}/api"
+
     postgres_url      = "jdbc:postgresql://${var.rds_database_hostname}/"
     postgres_name     = var.rds_database_name
     postgres_user     = var.rds_database_username

--- a/deployment/terraform/task-definitions/api.json.tmpl
+++ b/deployment/terraform/task-definitions/api.json.tmpl
@@ -5,7 +5,7 @@
     "environment": [
       {
         "name": "GRANARY_API_HOST",
-	"value": "${api_host}"
+        "value": "${api_host}"
       },
       {
         "name": "POSTGRES_URL",

--- a/deployment/terraform/task-definitions/api.json.tmpl
+++ b/deployment/terraform/task-definitions/api.json.tmpl
@@ -4,6 +4,10 @@
     "image": "${image}",
     "environment": [
       {
+        "name": "GRANARY_API_HOST",
+	"value": "${api_host}"
+      },
+      {
         "name": "POSTGRES_URL",
         "value": "${postgres_url}"
       },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
     environment:
       - AWS_PROFILE
       - ENVIRONMENT=development
+      - GRANARY_API_HOST=http://granary.service.internal/api
       - GRANARY_LOG_LEVEL=DEBUG
       - POSTGRES_URL=jdbc:postgresql://database.service.internal/
       - POSTGRES_NAME=granary
@@ -61,6 +62,8 @@ services:
       - ./data/:/opt/data/
       - $HOME/.aws:/root/.aws:ro
     working_dir: /opt/granary/
+    links:
+      - api:granary.service.internal
 
   sbt:
     image: openjdk:11-jdk


### PR DESCRIPTION
## Overview

This PR includes a `webhookUrl` in the arguments passed to any batch job kicked off from the predictions endpoint. It determines the url from a configured value, `GRANARY_API_HOST`, that is now included in the `docker-compose` file and deployment code.

### Checklist

Nothing new here except json merging so no checklist items were necessary

### Demo

well the test branch ci isn't really having a great time :thinking: 

## Testing Instructions

- make sure server still starts
- confirm json logic makes sense based on this [example job definition](https://console.aws.amazon.com/batch/home?region=us-east-1#/job-definitions/arn:aws:batch:us-east-1:615874746523:job-definition~2FgranaryPredictBuildings:2)
