### PR TITLE
Fix bugs around batch submission and inconsistency

### DIFF
--- a/api/src/main/resources/logback.xml
+++ b/api/src/main/resources/logback.xml
@@ -5,6 +5,7 @@
     </encoder>
   </appender>
   <logger name="com.rasterfoundry.granary" level="${GRANARY_LOG_LEVEL:-INFO}"/>
+  <logger name="org.http4s.blaze.channel.nio1" level="WARN"/>
   <root level="INFO">
     <appender-ref ref="STDOUT" />
   </root>

--- a/database/src/main/scala/com/rasterfoundry/granary/AWSBatch.scala
+++ b/database/src/main/scala/com/rasterfoundry/granary/AWSBatch.scala
@@ -32,10 +32,10 @@ object AWSBatch {
             val key = s"prediction-task-grids/$jobName/taskGrid.json"
             s3Client.putObject(dataBucket, key, v.noSpaces)
             val updated =
-              params.mapValues(_.noSpaces).updated("TASK_GRID", s"s3://${dataBucket}/$key")
+              params.mapValues(_.noSpaces.replace("\"", "")).updated("TASK_GRID", s"s3://${dataBucket}/$key")
             updated
           }
-        case _ => IO.pure(params.mapValues(_.noSpaces))
+        case _ => IO.pure(params.mapValues(_.noSpaces.replace("\"", "")))
       }
 
       val jobRequestIO = updatedParametersIO map { updatedParameters =>

--- a/database/src/main/scala/com/rasterfoundry/granary/PredictionDao.scala
+++ b/database/src/main/scala/com/rasterfoundry/granary/PredictionDao.scala
@@ -116,7 +116,7 @@ object PredictionDao {
           model.jobDefinition,
           model.jobQueue,
           prediction.arguments.deepMerge(prediction.webhookId map { webhookId =>
-            Map("webhookUrl" -> s"${apiHost}/predictions/${prediction.id}/results/${webhookId}").asJson
+            Map("WEBHOOK_URL" -> s"${apiHost}/predictions/${prediction.id}/results/${webhookId}").asJson
           } getOrElse { ().asJson }),
           batchSafeJobName(s"${model.name}-${prediction.id}"),
           dataBucket

--- a/deployment/terraform/api.tf
+++ b/deployment/terraform/api.tf
@@ -26,7 +26,10 @@ resource "aws_security_group" "api" {
 #
 resource "aws_lb" "api" {
   name            = "alb${var.project}API"
-  security_groups = [aws_security_group.alb.id]
+  security_groups = flatten([
+      aws_security_group.alb.id,
+      aws_security_group.alb_whitelist_ec2.*.id,
+  ])
   subnets         = var.vpc_public_subnet_ids
 
   enable_http2 = true

--- a/deployment/terraform/api.tf
+++ b/deployment/terraform/api.tf
@@ -104,7 +104,7 @@ resource "aws_ecs_task_definition" "api" {
   cpu                      = var.fargate_api_cpu
   memory                   = var.fargate_api_memory
 
-  task_role_arn      = aws_iam_role.ecs_task_execution_role.arn
+  task_role_arn      = aws_iam_role.ecs_task_role.arn
   execution_role_arn = aws_iam_role.ecs_task_execution_role.arn
 
   container_definitions = templatefile("${path.module}/task-definitions/api.json.tmpl", {

--- a/deployment/terraform/api.tf
+++ b/deployment/terraform/api.tf
@@ -104,6 +104,7 @@ resource "aws_ecs_task_definition" "api" {
   cpu                      = var.fargate_api_cpu
   memory                   = var.fargate_api_memory
 
+  task_role_arn      = aws_iam_role.ecs_task_execution_role.arn
   execution_role_arn = aws_iam_role.ecs_task_execution_role.arn
 
   container_definitions = templatefile("${path.module}/task-definitions/api.json.tmpl", {

--- a/deployment/terraform/firewall.tf
+++ b/deployment/terraform/firewall.tf
@@ -105,13 +105,7 @@ resource "aws_security_group" "alb_whitelist_ec2" {
     from_port       = 0
     to_port         = 65535
     protocol        = "tcp"
-    security_groups = ["${module.container_service_cluster.container_instance_security_group_id}"]
-  }
-
-  tags {
-    Name        = "sgAPIServerLoadBalancer"
-    Project     = "${var.project}"
-    Environment = "${var.environment}"
+    security_groups = ["${aws_security_group.api.id}"]
   }
 }
 
@@ -133,5 +127,5 @@ resource "aws_security_group_rule" "alb_api_server_container_instance_all_egress
   protocol  = "tcp"
 
   security_group_id        = "${aws_security_group.alb.id}"
-  source_security_group_id = "${module.container_service_cluster.container_instance_security_group_id}"
+  source_security_group_id = "${aws_security_gorup.api.id}"
 }

--- a/deployment/terraform/firewall.tf
+++ b/deployment/terraform/firewall.tf
@@ -99,6 +99,7 @@ locals {
 }
 
 resource "aws_security_group" "alb_whitelist_ec2" {
+  count = "${length(local.ec2_cidr_block_chunks)}"
   vpc_id = "${var.vpc_id}"
 
   egress {
@@ -116,16 +117,6 @@ resource "aws_security_group_rule" "alb_api_server_ec2_https_ingress" {
   from_port         = 443
   to_port           = 443
   protocol          = "tcp"
-  cidr_blocks       = ["${local.ec2_cidr_block_chunks[count.index]}"]
+  cidr_blocks       = local.ec2_cidr_block_chunks[count.index]
   security_group_id = "${aws_security_group.alb_whitelist_ec2.*.id[count.index]}"
-}
-
-resource "aws_security_group_rule" "alb_api_server_container_instance_all_egress" {
-  type      = "egress"
-  from_port = 0
-  to_port   = 65535
-  protocol  = "tcp"
-
-  security_group_id        = "${aws_security_group.alb.id}"
-  source_security_group_id = "${aws_security_gorup.api.id}"
 }

--- a/deployment/terraform/firewall.tf
+++ b/deployment/terraform/firewall.tf
@@ -99,7 +99,7 @@ locals {
 }
 
 resource "aws_security_group" "alb_whitelist_ec2" {
-  vpc_id = "${module.vpc.id}"
+  vpc_id = "${var.vpc_id}"
 
   egress {
     from_port       = 0

--- a/deployment/terraform/firewall.tf
+++ b/deployment/terraform/firewall.tf
@@ -88,3 +88,50 @@ resource "aws_security_group_rule" "container_instance_alb_all_ingress" {
   security_group_id        = aws_security_group.api.id
   source_security_group_id = aws_security_group.alb.id
 }
+
+data "aws_ip_ranges" "ec2" {
+  regions  = ["${var.aws_region}"]
+  services = ["ec2"]
+}
+
+locals {
+  ec2_cidr_block_chunks = "${chunklist(data.aws_ip_ranges.ec2.cidr_blocks, 40)}"
+}
+
+resource "aws_security_group" "alb_whitelist_ec2" {
+  vpc_id = "${module.vpc.id}"
+
+  egress {
+    from_port       = 0
+    to_port         = 65535
+    protocol        = "tcp"
+    security_groups = ["${module.container_service_cluster.container_instance_security_group_id}"]
+  }
+
+  tags {
+    Name        = "sgAPIServerLoadBalancer"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}
+
+resource "aws_security_group_rule" "alb_api_server_ec2_https_ingress" {
+  count = "${length(local.ec2_cidr_block_chunks)}"
+
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["${local.ec2_cidr_block_chunks[count.index]}"]
+  security_group_id = "${aws_security_group.alb_whitelist_ec2.*.id[count.index]}"
+}
+
+resource "aws_security_group_rule" "alb_api_server_container_instance_all_egress" {
+  type      = "egress"
+  from_port = 0
+  to_port   = 65535
+  protocol  = "tcp"
+
+  security_group_id        = "${aws_security_group.alb.id}"
+  source_security_group_id = "${module.container_service_cluster.container_instance_security_group_id}"
+}

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -25,3 +25,13 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {
   role       = aws_iam_role.ecs_task_execution_role.name
   policy_arn = var.aws_ecs_task_execution_role_policy_arn
 }
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy_s3" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy_batch" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSBatchFullAccess"
+}

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -21,17 +21,22 @@ resource "aws_iam_role" "ecs_task_execution_role" {
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_role.json
 }
 
+resource "aws_iam_role" "ecs_task_role" {
+  name               = "ecs${var.project}TaskRole"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume_role.json
+}
+
 resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {
   role       = aws_iam_role.ecs_task_execution_role.name
   policy_arn = var.aws_ecs_task_execution_role_policy_arn
 }
 
-resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy_s3" {
-  role       = aws_iam_role.ecs_task_execution_role.name
+resource "aws_iam_role_policy_attachment" "ecs_task_role_policy_s3" {
+  role       = aws_iam_role.ecs_task_role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
 }
 
-resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy_batch" {
+resource "aws_iam_role_policy_attachment" "ecs_task_role_policy_batch" {
   role       = aws_iam_role.ecs_task_execution_role.name
   policy_arn = "arn:aws:iam::aws:policy/AWSBatchFullAccess"
 }

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -37,6 +37,6 @@ resource "aws_iam_role_policy_attachment" "ecs_task_role_policy_s3" {
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_task_role_policy_batch" {
-  role       = aws_iam_role.ecs_task_execution_role.name
+  role       = aws_iam_role.ecs_task_role.name
   policy_arn = "arn:aws:iam::aws:policy/AWSBatchFullAccess"
 }

--- a/deployment/terraform/task-definitions/api.json.tmpl
+++ b/deployment/terraform/task-definitions/api.json.tmpl
@@ -30,6 +30,10 @@
       {
         "name": "GRANARY_TRACING_SINK",
         "value": "${granary_tracing_sink}"
+      },
+      {
+        "name": "ENVIRONMENT",
+        "value": "production"
       }
     ],
     "portMappings": [


### PR DESCRIPTION
## Overview

This PR makes the casing of the magic webhook URL parameter match the casing of the magic TASK_GRID parameter. As a consumer of the application, it was frustrating a minute ago when these were different. All of our previous examples were in upper snake case, so I switched webhook URL to match that instead of the other way around. Also a bunch of things were wrong with our interaction with AWS Batch and our deployed configuration.

### Checklist

none necessary

## Testing Instructions

- ci only but I may push up more small changes while I'm messing with this