### PR TITLE
Attempt to Sign S3 output locations in API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,7 @@ lazy val datamodelSettings = commonSettings ++ Seq(
 )
 
 lazy val datamodelDependencies = commonDependencies ++ Seq(
+  Dependencies.awsS3,
   Dependencies.catsScalacheck,
   Dependencies.circeCore,
   Dependencies.circeGeneric,

--- a/database/src/main/scala/com/rasterfoundry/granary/AWSBatch.scala
+++ b/database/src/main/scala/com/rasterfoundry/granary/AWSBatch.scala
@@ -32,7 +32,9 @@ object AWSBatch {
             val key = s"prediction-task-grids/$jobName/taskGrid.json"
             s3Client.putObject(dataBucket, key, v.noSpaces)
             val updated =
-              params.mapValues(_.noSpaces.replace("\"", "")).updated("TASK_GRID", s"s3://${dataBucket}/$key")
+              params
+                .mapValues(_.noSpaces.replace("\"", ""))
+                .updated("TASK_GRID", s"s3://${dataBucket}/$key")
             updated
           }
         case _ => IO.pure(params.mapValues(_.noSpaces.replace("\"", "")))

--- a/datamodel/src/main/scala/com/rasterfoundry/granary/Prediction.scala
+++ b/datamodel/src/main/scala/com/rasterfoundry/granary/Prediction.scala
@@ -2,9 +2,12 @@ package com.rasterfoundry.granary.datamodel
 
 import io.circe._
 import io.circe.generic.semiauto._
-
 import java.time.Instant
-import java.util.UUID
+import java.util.{Date, UUID}
+
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3URI}
+
+import scala.util.{Failure, Success, Try}
 
 case class Prediction(
     id: UUID,
@@ -15,7 +18,24 @@ case class Prediction(
     statusReason: Option[String],
     outputLocation: Option[String],
     webhookId: Option[UUID]
-)
+) {
+
+  def signS3OutputLocation(s3Client: AmazonS3): Prediction = {
+    val updatedLocation = outputLocation map {
+      case s3Location if s3Location.startsWith("s3://") =>
+        Try {
+          val s3Url      = new AmazonS3URI(s3Location)
+          val expiryDate = Date.from(Instant.now().plusSeconds(60 * 60))
+          s3Client.generatePresignedUrl(s3Url.getBucket, s3Url.getKey, expiryDate)
+        } match {
+          case Success(v) => v.toString
+          case Failure(_) => s3Location
+        }
+      case location => location
+    }
+    this.copy(outputLocation = updatedLocation)
+  }
+}
 
 object Prediction {
   implicit val encPrediction: Encoder[Prediction] = deriveEncoder


### PR DESCRIPTION
## Overview

Clients of a granary API may want to be able to download prediction results directly even if they do not have access or the ability to sign S3 requests themselves - for instance when a front-end client application is querying for results. To enable this the following PR signs S3 URLs for the `outputLocation`.

### Checklist

~- [ ] New tables and queries have appropriate indices added~
~- [ ] Any new migrations have been audited to make sure they won't kill the application while being applied~
~- [ ] Any new API endpoints have tests~
~- [ ] Any frontend changes are hidden behind a feature flag~

### Notes

The change here tries to be resilient to issues generating a signed URL - for instance if credentials aren't available where the API is running - but there is a failure mode that is allowed under this PR. The AWS client will generate signed URLs even _if_ the S3 object isn't available with the underlying credentials.

I'm not sure the best way to deal with this. We _could_ only sign URLs that include a whitelist of `buckets` as a configuration option (including the data bucket by default). This could still result in the same issue if the application is misconfigured, but at least this allows for fixing the problem via configuration.

Another option is to enable signing via an environment variable - that wouldn't eliminate the problem, but would at least let clients get the original URI as well. Alternatively I could include another field in predictions (`signedURL`) in addition to the original value.

None of the above are too onerous - we could do them all if we wanted - but I'm not convinced that we need to from the start either.

## Testing Instructions

- Rebuild server, ensure recent development data is loaded
- Run the following SQL:
```
update predictions set output_location = 's3://not-real/test.json' where id = 'c4d9e1c2-0a14-472d-b27c-380a3c1f99a8';
update predictions set output_location = 'https://not-s3-url.com' where id = '386767f6-3c81-4c13-859e-1f8f7edb72a2';
```
- Inspect the output of the following:
```
http :8080/api/predictions | jq .[].outputLocation
```

Closes #48 
