### PR TITLE
Enable auth in deployment by default

### DIFF
--- a/api/src/main/scala/com/rasterfoundry/granary/Server.scala
+++ b/api/src/main/scala/com/rasterfoundry/granary/Server.scala
@@ -76,24 +76,25 @@ object ApiServer extends IOApp {
       docRoutes   = new SwaggerHttp4s(docs.toYaml).routes
       helloRoutes = new HelloService(tracingContextBuilder).routes
       modelRoutes = new ModelService(tracingContextBuilder, transactor).routes
-      predictionRoutes = new PredictionService(
+      predictionService = new PredictionService(
         tracingContextBuilder,
         transactor,
         s3Config.dataBucket,
         metaConfig.apiHost
-      ).routes
+      )
+      predictionRoutes = predictionService.routes
       router = RequestResponseLogger
         .httpRoutes(false, false) {
           CORS(
             Router(
-              "/api" -> (
+              "/api" -> ((
                 Auth.customAuthMiddleware(
                   modelRoutes <+> predictionRoutes,
                   helloRoutes <+> docRoutes,
                   authConfig,
                   transactor
                 )
-              )
+              ) <+> predictionService.addResultsRoutes)
             )
           )
         }

--- a/api/src/main/scala/com/rasterfoundry/granary/services/PredictionService.scala
+++ b/api/src/main/scala/com/rasterfoundry/granary/services/PredictionService.scala
@@ -98,11 +98,13 @@ class PredictionService[F[_]: Sync](
       })
     }
 
-  val list       = PredictionEndpoints.list.toRoutes(Function.tupled(listPredictions))
-  val detail     = PredictionEndpoints.idLookup.toRoutes(getById)
-  val create     = PredictionEndpoints.create.toRoutes(createPrediction)
-  val addResults = PredictionEndpoints.addResults.toRoutes(Function.tupled(addPredictionResults))
+  val list   = PredictionEndpoints.list.toRoutes(Function.tupled(listPredictions))
+  val detail = PredictionEndpoints.idLookup.toRoutes(getById)
+  val create = PredictionEndpoints.create.toRoutes(createPrediction)
 
-  val routes: HttpRoutes[F] = detail <+> create <+> list <+> addResults
+  val addResultsRoutes =
+    PredictionEndpoints.addResults.toRoutes(Function.tupled(addPredictionResults))
+
+  val routes: HttpRoutes[F] = detail <+> create <+> list
 
 }

--- a/api/src/test/scala/com/rasterfoundry/granary/PredictionServiceSpec.scala
+++ b/api/src/test/scala/com/rasterfoundry/granary/PredictionServiceSpec.scala
@@ -55,7 +55,7 @@ class PredictionServiceSpec
       prediction: Prediction,
       webhookId: UUID
   ): OptionT[IO, Response[IO]] =
-    predictionService.routes.run(
+    predictionService.addResultsRoutes.run(
       Request[IO](
         method = Method.POST,
         uri = Uri

--- a/deployment/terraform/api.tf
+++ b/deployment/terraform/api.tf
@@ -122,6 +122,7 @@ resource "aws_ecs_task_definition" "api" {
 
     granary_log_level    = var.api_log_level
     granary_tracing_sink = var.api_tracing_sink
+    granary_auth_enabled = var.granary_auth_enabled
 
     project = var.project
     aws_region = var.aws_region

--- a/deployment/terraform/task-definitions/api.json.tmpl
+++ b/deployment/terraform/task-definitions/api.json.tmpl
@@ -32,6 +32,10 @@
         "value": "${granary_tracing_sink}"
       },
       {
+        "name": "AUTH_ENABLED",
+        "value": "${granary_auth_enabled}"
+      },
+      {
         "name": "ENVIRONMENT",
         "value": "production"
       }

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -151,3 +151,8 @@ variable "aws_batch_service_role_policy_arn" {
   default = "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
   type    = string
 }
+
+variable "granary_auth_enabled" {
+  default = "true"
+  type = string
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
 
 // Versions
 object Versions {
-  val awsSDK                 = "1.11.703"
+  val awsSDK                 = "1.11.707"
   val CatsScalacheckVersion  = "0.2.0"
   val CirceVersion           = "0.12.3"
   val CirceJsonSchemaVersion = "0.1.0"
@@ -18,7 +18,7 @@ object Versions {
   val ScapegoatVersion       = "1.3.11"
   val ScalacheckVersion      = "1.14.3"
   val Specs2Version          = "4.8.3"
-  val TapirVersion           = "0.12.12"
+  val TapirVersion           = "0.12.15"
 }
 
 object Dependencies {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("org.lyranthe.sbt"          % "partial-unification"      % "1.1.2")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"             % "0.1.10")
 addSbtPlugin("io.spray"                  % "sbt-revolver"             % "0.9.1")
-addSbtPlugin("org.scalameta"             % "sbt-scalafmt"             % "2.0.7")
+addSbtPlugin("org.scalameta"             % "sbt-scalafmt"             % "2.3.0")
 addSbtPlugin("com.sksamuel.scapegoat"    %% "sbt-scapegoat"           % "1.1.0")
 addSbtPlugin("ch.epfl.scala"             % "sbt-scalafix"             % "0.9.11")
 addSbtPlugin("com.eed3si9n"              % "sbt-assembly"             % "0.14.10")


### PR DESCRIPTION
## Overview

Makes authentication enabled by default when deployed

### Notes

It's a little weird that we return a 404 when a request fails authentication, but this PR didn't add that and it's _ok_ for now

## Testing Instructions

- Try to hit `https://granary.rasterfoundry.com/api/predictions`