### PR TITLE
Add file input component

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,6 @@ Brief description of what this PR does, and why it is needed.
 - [ ] New tables and queries have appropriate indices added
 - [ ] Any new migrations have been audited to make sure they won't kill the application while being applied
 - [ ] Any new API endpoints have tests
-- [ ] Any frontend changes are hidden behind a feature flag
 
 ### Demo
 

--- a/api/src/main/resources/assets/index.html
+++ b/api/src/main/resources/assets/index.html
@@ -19978,7 +19978,7 @@ var $author$project$Pages$TaskList$schemaToForm = F4(
 											_List_Nil,
 											_List_fromArray(
 												[
-													$mdgriffith$elm_ui$Element$text('Successful geojson upload!')
+													A2($author$project$Styled$styledPrimaryText, _List_Nil, 'Successful geojson upload!')
 												]))),
 									data);
 							} else {

--- a/api/src/main/resources/assets/index.html
+++ b/api/src/main/resources/assets/index.html
@@ -19556,10 +19556,7 @@ var $author$project$Pages$TaskList$makeErr = function (err) {
 				function (s) {
 					return A2(
 						$mdgriffith$elm_ui$Element$row,
-						_List_fromArray(
-							[
-								$mdgriffith$elm_ui$Element$spacing(3)
-							]),
+						_List_Nil,
 						_List_fromArray(
 							[
 								$mdgriffith$elm_ui$Element$text('Missing field: '),
@@ -19576,10 +19573,7 @@ var $author$project$Pages$TaskList$makeErr = function (err) {
 				[
 					A2(
 					$mdgriffith$elm_ui$Element$row,
-					_List_fromArray(
-						[
-							$mdgriffith$elm_ui$Element$spacing(3)
-						]),
+					_List_Nil,
 					_List_fromArray(
 						[
 							$mdgriffith$elm_ui$Element$text('Invalid json')
@@ -19589,31 +19583,15 @@ var $author$project$Pages$TaskList$makeErr = function (err) {
 			var t = _v0.a;
 			return _List_fromArray(
 				[
-					A2(
-					$mdgriffith$elm_ui$Element$row,
-					_List_fromArray(
-						[
-							$mdgriffith$elm_ui$Element$spacing(3)
-						]),
-					_List_fromArray(
-						[
-							$mdgriffith$elm_ui$Element$text(t)
-						]))
+					$mdgriffith$elm_ui$Element$text(t)
 				]);
 		case 'RequiredProperty':
 			return _List_Nil;
 		default:
 			return _List_fromArray(
 				[
-					A2(
-					$mdgriffith$elm_ui$Element$row,
-					_List_fromArray(
-						[
-							$mdgriffith$elm_ui$Element$spacing(3)
-						]),
-					$elm$core$List$singleton(
-						$mdgriffith$elm_ui$Element$text(
-							'I can\'t tell what else is wrong with ' + $author$project$Pages$TaskList$getErrField(err))))
+					$mdgriffith$elm_ui$Element$text(
+					'I can\'t tell what else is wrong with ' + $author$project$Pages$TaskList$getErrField(err))
 				]);
 	}
 };
@@ -19629,8 +19607,7 @@ var $author$project$Pages$TaskList$makeHelpfulErrorMessage = function (err) {
 				_List_fromArray(
 					[
 						$mdgriffith$elm_ui$Element$width(
-						A2($mdgriffith$elm_ui$Element$minimum, 300, $mdgriffith$elm_ui$Element$fill)),
-						$mdgriffith$elm_ui$Element$spacing(3)
+						A2($mdgriffith$elm_ui$Element$minimum, 300, $mdgriffith$elm_ui$Element$fill))
 					]),
 				_List_fromArray(
 					[
@@ -20061,7 +20038,8 @@ var $author$project$Pages$TaskList$schemaToForm = F4(
 					$mdgriffith$elm_ui$Element$column,
 					_List_fromArray(
 						[
-							$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill)
+							$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill),
+							$mdgriffith$elm_ui$Element$spacing(5)
 						]),
 					A2(
 						$elm$core$List$cons,

--- a/api/src/main/resources/assets/index.html
+++ b/api/src/main/resources/assets/index.html
@@ -18922,6 +18922,20 @@ var $author$project$Pages$ExecutionList$executionList = function (model) {
 			$author$project$Pages$ExecutionList$nameSearchInput(model.executionNameSearch),
 			A2($elm$core$List$map, card, model.executions)));
 };
+var $author$project$Types$GoHome = {$: 'GoHome'};
+var $mdgriffith$elm_ui$Internal$Model$Right = {$: 'Right'};
+var $mdgriffith$elm_ui$Element$alignRight = $mdgriffith$elm_ui$Internal$Model$AlignX($mdgriffith$elm_ui$Internal$Model$Right);
+var $author$project$Main$homeLink = A2(
+	$mdgriffith$elm_ui$Element$Input$button,
+	_List_fromArray(
+		[
+			$mdgriffith$elm_ui$Element$alignRight,
+			$mdgriffith$elm_ui$Element$padding(12)
+		]),
+	{
+		label: $mdgriffith$elm_ui$Element$text('🏠'),
+		onPress: $elm$core$Maybe$Just($author$project$Types$GoHome)
+	});
 var $mdgriffith$elm_ui$Internal$Model$OnlyDynamic = F2(
 	function (a, b) {
 		return {$: 'OnlyDynamic', a: a, b: b};
@@ -19367,72 +19381,24 @@ var $author$project$Main$loginPage = function (model) {
 					]))
 			]));
 };
-var $author$project$Types$GoHome = {$: 'GoHome'};
-var $author$project$Main$homeLink = A2(
-	$mdgriffith$elm_ui$Element$Input$button,
-	_List_Nil,
-	{
-		label: $mdgriffith$elm_ui$Element$text('🏠'),
-		onPress: $elm$core$Maybe$Just($author$project$Types$GoHome)
-	});
 var $author$project$Main$logoTop = function (rest) {
 	return A2(
 		$mdgriffith$elm_ui$Element$column,
 		_List_fromArray(
 			[
-				$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill),
+				$mdgriffith$elm_ui$Element$width(
+				A2($mdgriffith$elm_ui$Element$maximum, 1024, $mdgriffith$elm_ui$Element$fill)),
 				$mdgriffith$elm_ui$Element$centerX
 			]),
-		_Utils_ap(
-			_List_fromArray(
-				[
-					A2(
-					$mdgriffith$elm_ui$Element$row,
-					_List_fromArray(
-						[
-							$mdgriffith$elm_ui$Element$centerX,
-							$mdgriffith$elm_ui$Element$width(
-							A2($mdgriffith$elm_ui$Element$maximum, 400, $mdgriffith$elm_ui$Element$fill))
-						]),
-					_List_fromArray(
-						[
-							A2(
-							$mdgriffith$elm_ui$Element$column,
-							_List_fromArray(
-								[
-									$mdgriffith$elm_ui$Element$width(
-									$mdgriffith$elm_ui$Element$fillPortion(9)),
-									$mdgriffith$elm_ui$Element$height($mdgriffith$elm_ui$Element$fill)
-								]),
-							_List_fromArray(
-								[
-									A2(
-									$author$project$Main$logo,
-									_List_fromArray(
-										[
-											$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill)
-										]),
-									100)
-								])),
-							A2(
-							$mdgriffith$elm_ui$Element$column,
-							_List_fromArray(
-								[
-									$mdgriffith$elm_ui$Element$width(
-									$mdgriffith$elm_ui$Element$fillPortion(1)),
-									$mdgriffith$elm_ui$Element$height($mdgriffith$elm_ui$Element$fill)
-								]),
-							_List_fromArray(
-								[
-									A2(
-									$mdgriffith$elm_ui$Element$row,
-									_List_fromArray(
-										[$mdgriffith$elm_ui$Element$centerY]),
-									_List_fromArray(
-										[$author$project$Main$homeLink]))
-								]))
-						]))
-				]),
+		A2(
+			$elm$core$List$cons,
+			A2(
+				$author$project$Main$logo,
+				_List_fromArray(
+					[
+						$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill)
+					]),
+				100),
 			rest));
 };
 var $author$project$Types$CreateExecution = function (a) {
@@ -20105,8 +20071,6 @@ var $author$project$Types$NewExecutionForTask = function (a) {
 };
 var $mdgriffith$elm_ui$Internal$Model$Left = {$: 'Left'};
 var $mdgriffith$elm_ui$Element$alignLeft = $mdgriffith$elm_ui$Internal$Model$AlignX($mdgriffith$elm_ui$Internal$Model$Left);
-var $mdgriffith$elm_ui$Internal$Model$Right = {$: 'Right'};
-var $mdgriffith$elm_ui$Element$alignRight = $mdgriffith$elm_ui$Internal$Model$AlignX($mdgriffith$elm_ui$Internal$Model$Right);
 var $author$project$Styled$styledSecondaryText = F2(
 	function (attrs, s) {
 		return A2(
@@ -20305,6 +20269,7 @@ var $author$project$Main$view = function (model) {
 								$mdgriffith$elm_ui$Element$layout,
 								_List_fromArray(
 									[
+										$mdgriffith$elm_ui$Element$inFront($author$project$Main$homeLink),
 										$mdgriffith$elm_ui$Element$width(
 										A2($mdgriffith$elm_ui$Element$minimum, 1024, $mdgriffith$elm_ui$Element$fill))
 									]),
@@ -20323,6 +20288,7 @@ var $author$project$Main$view = function (model) {
 								$mdgriffith$elm_ui$Element$layout,
 								_List_fromArray(
 									[
+										$mdgriffith$elm_ui$Element$inFront($author$project$Main$homeLink),
 										$mdgriffith$elm_ui$Element$width(
 										A2($mdgriffith$elm_ui$Element$minimum, 1024, $mdgriffith$elm_ui$Element$fill))
 									]),

--- a/api/src/main/resources/assets/index.html
+++ b/api/src/main/resources/assets/index.html
@@ -11940,7 +11940,7 @@ var $author$project$Main$update = F2(
 							$elm$core$Platform$Cmd$none);
 					}
 				}
-			case 'GeoJsonInputMouseInteraction':
+			default:
 				var event = msg.a;
 				var tlm = function () {
 					var _v10 = model.route;
@@ -11956,7 +11956,7 @@ var $author$project$Main$update = F2(
 						return A2(
 							$elm$file$File$Select$files,
 							_List_fromArray(
-								['*.geojson', '*.json']),
+								['application/geo+json', 'application/json']),
 							$author$project$Types$GotFiles);
 					} else {
 						return $elm$core$Platform$Cmd$none;
@@ -11970,8 +11970,6 @@ var $author$project$Main$update = F2(
 								A2($author$project$Pages$TaskList$setInputState, event, tlm))
 						}),
 					cmd);
-			default:
-				return _Utils_Tuple2(model, $elm$core$Platform$Cmd$none);
 		}
 	});
 var $mdgriffith$elm_ui$Internal$Model$AlignX = function (a) {

--- a/api/src/main/resources/assets/index.html
+++ b/api/src/main/resources/assets/index.html
@@ -4777,6 +4777,184 @@ function _Http_track(router, xhr, tracker)
 	});
 }
 
+
+// DECODER
+
+var _File_decoder = _Json_decodePrim(function(value) {
+	// NOTE: checks if `File` exists in case this is run on node
+	return (typeof File !== 'undefined' && value instanceof File)
+		? $elm$core$Result$Ok(value)
+		: _Json_expecting('a FILE', value);
+});
+
+
+// METADATA
+
+function _File_name(file) { return file.name; }
+function _File_mime(file) { return file.type; }
+function _File_size(file) { return file.size; }
+
+function _File_lastModified(file)
+{
+	return $elm$time$Time$millisToPosix(file.lastModified);
+}
+
+
+// DOWNLOAD
+
+var _File_downloadNode;
+
+function _File_getDownloadNode()
+{
+	return _File_downloadNode || (_File_downloadNode = document.createElement('a'));
+}
+
+var _File_download = F3(function(name, mime, content)
+{
+	return _Scheduler_binding(function(callback)
+	{
+		var blob = new Blob([content], {type: mime});
+
+		// for IE10+
+		if (navigator.msSaveOrOpenBlob)
+		{
+			navigator.msSaveOrOpenBlob(blob, name);
+			return;
+		}
+
+		// for HTML5
+		var node = _File_getDownloadNode();
+		var objectUrl = URL.createObjectURL(blob);
+		node.href = objectUrl;
+		node.download = name;
+		_File_click(node);
+		URL.revokeObjectURL(objectUrl);
+	});
+});
+
+function _File_downloadUrl(href)
+{
+	return _Scheduler_binding(function(callback)
+	{
+		var node = _File_getDownloadNode();
+		node.href = href;
+		node.download = '';
+		node.origin === location.origin || (node.target = '_blank');
+		_File_click(node);
+	});
+}
+
+
+// IE COMPATIBILITY
+
+function _File_makeBytesSafeForInternetExplorer(bytes)
+{
+	// only needed by IE10 and IE11 to fix https://github.com/elm/file/issues/10
+	// all other browsers can just run `new Blob([bytes])` directly with no problem
+	//
+	return new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+}
+
+function _File_click(node)
+{
+	// only needed by IE10 and IE11 to fix https://github.com/elm/file/issues/11
+	// all other browsers have MouseEvent and do not need this conditional stuff
+	//
+	if (typeof MouseEvent === 'function')
+	{
+		node.dispatchEvent(new MouseEvent('click'));
+	}
+	else
+	{
+		var event = document.createEvent('MouseEvents');
+		event.initMouseEvent('click', true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
+		document.body.appendChild(node);
+		node.dispatchEvent(event);
+		document.body.removeChild(node);
+	}
+}
+
+
+// UPLOAD
+
+var _File_node;
+
+function _File_uploadOne(mimes)
+{
+	return _Scheduler_binding(function(callback)
+	{
+		_File_node = document.createElement('input');
+		_File_node.type = 'file';
+		_File_node.accept = A2($elm$core$String$join, ',', mimes);
+		_File_node.addEventListener('change', function(event)
+		{
+			callback(_Scheduler_succeed(event.target.files[0]));
+		});
+		_File_click(_File_node);
+	});
+}
+
+function _File_uploadOneOrMore(mimes)
+{
+	return _Scheduler_binding(function(callback)
+	{
+		_File_node = document.createElement('input');
+		_File_node.type = 'file';
+		_File_node.multiple = true;
+		_File_node.accept = A2($elm$core$String$join, ',', mimes);
+		_File_node.addEventListener('change', function(event)
+		{
+			var elmFiles = _List_fromArray(event.target.files);
+			callback(_Scheduler_succeed(_Utils_Tuple2(elmFiles.a, elmFiles.b)));
+		});
+		_File_click(_File_node);
+	});
+}
+
+
+// CONTENT
+
+function _File_toString(blob)
+{
+	return _Scheduler_binding(function(callback)
+	{
+		var reader = new FileReader();
+		reader.addEventListener('loadend', function() {
+			callback(_Scheduler_succeed(reader.result));
+		});
+		reader.readAsText(blob);
+		return function() { reader.abort(); };
+	});
+}
+
+function _File_toBytes(blob)
+{
+	return _Scheduler_binding(function(callback)
+	{
+		var reader = new FileReader();
+		reader.addEventListener('loadend', function() {
+			callback(_Scheduler_succeed(new DataView(reader.result)));
+		});
+		reader.readAsArrayBuffer(blob);
+		return function() { reader.abort(); };
+	});
+}
+
+function _File_toUrl(blob)
+{
+	return _Scheduler_binding(function(callback)
+	{
+		var reader = new FileReader();
+		reader.addEventListener('loadend', function() {
+			callback(_Scheduler_succeed(reader.result));
+		});
+		reader.readAsDataURL(blob);
+		return function() { reader.abort(); };
+	});
+}
+
+
+
 function _Url_percentEncode(string)
 {
 	return encodeURIComponent(string);
@@ -5677,7 +5855,7 @@ var $elm$url$Url$toString = function (url) {
 var $author$project$Main$init = F3(
 	function (_v0, url, key) {
 		return _Utils_Tuple2(
-			{executionListModel: $elm$core$Maybe$Nothing, key: key, route: $author$project$Main$Login, secrets: $elm$core$Maybe$Nothing, secretsUnsubmitted: $elm$core$Maybe$Nothing, taskListModel: $elm$core$Maybe$Nothing, url: url},
+			{key: key, route: $author$project$Main$Login, secrets: $elm$core$Maybe$Nothing, secretsUnsubmitted: $elm$core$Maybe$Nothing, url: url},
 			A2(
 				$elm$browser$Browser$Navigation$pushUrl,
 				key,
@@ -5685,9 +5863,19 @@ var $author$project$Main$init = F3(
 	});
 var $elm$core$Platform$Sub$batch = _Platform_batch;
 var $elm$core$Platform$Sub$none = $elm$core$Platform$Sub$batch(_List_Nil);
+var $author$project$Types$DecodingError = function (a) {
+	return {$: 'DecodingError', a: a};
+};
 var $author$project$Main$ExecutionList = function (a) {
 	return {$: 'ExecutionList', a: a};
 };
+var $author$project$Types$GeoJsonData = function (a) {
+	return {$: 'GeoJsonData', a: a};
+};
+var $author$project$Types$GotFiles = F2(
+	function (a, b) {
+		return {$: 'GotFiles', a: a, b: b};
+	});
 var $1602$json_schema$Json$Schema$Validation$InvalidType = function (a) {
 	return {$: 'InvalidType', a: a};
 };
@@ -5698,7 +5886,12 @@ var $1602$json_schema$Json$Schema$Validation$JsonPointer = F2(
 var $1602$json_schema$Json$Schema$Definitions$ObjectSchema = function (a) {
 	return {$: 'ObjectSchema', a: a};
 };
-var $author$project$Main$TaskList = {$: 'TaskList'};
+var $author$project$Types$SchemaError = function (a) {
+	return {$: 'SchemaError', a: a};
+};
+var $author$project$Main$TaskList = function (a) {
+	return {$: 'TaskList', a: a};
+};
 var $elm$core$Maybe$andThen = F2(
 	function (callback, maybeValue) {
 		if (maybeValue.$ === 'Just') {
@@ -5708,11 +5901,234 @@ var $elm$core$Maybe$andThen = F2(
 			return $elm$core$Maybe$Nothing;
 		}
 	});
-var $elm$core$Basics$composeL = F3(
-	function (g, f, x) {
-		return g(
-			f(x));
+var $elm$json$Json$Decode$decodeString = _Json_runOnString;
+var $elm$json$Json$Decode$float = _Json_decodeFloat;
+var $elm$json$Json$Decode$list = _Json_decodeList;
+var $mgold$elm_geojson$GeoJson$decodeBbox = $elm$json$Json$Decode$list($elm$json$Json$Decode$float);
+var $mgold$elm_geojson$GeoJson$Feature = function (a) {
+	return {$: 'Feature', a: a};
+};
+var $mgold$elm_geojson$GeoJson$FeatureCollection = function (a) {
+	return {$: 'FeatureCollection', a: a};
+};
+var $mgold$elm_geojson$GeoJson$Geometry = function (a) {
+	return {$: 'Geometry', a: a};
+};
+var $elm$json$Json$Decode$andThen = _Json_andThen;
+var $mgold$elm_geojson$GeoJson$FeatureObject = F3(
+	function (geometry, properties, id) {
+		return {geometry: geometry, id: id, properties: properties};
 	});
+var $mgold$elm_geojson$GeoJson$GeometryCollection = function (a) {
+	return {$: 'GeometryCollection', a: a};
+};
+var $mgold$elm_geojson$GeoJson$LineString = function (a) {
+	return {$: 'LineString', a: a};
+};
+var $mgold$elm_geojson$GeoJson$MultiLineString = function (a) {
+	return {$: 'MultiLineString', a: a};
+};
+var $mgold$elm_geojson$GeoJson$MultiPoint = function (a) {
+	return {$: 'MultiPoint', a: a};
+};
+var $mgold$elm_geojson$GeoJson$MultiPolygon = function (a) {
+	return {$: 'MultiPolygon', a: a};
+};
+var $mgold$elm_geojson$GeoJson$Point = function (a) {
+	return {$: 'Point', a: a};
+};
+var $mgold$elm_geojson$GeoJson$Polygon = function (a) {
+	return {$: 'Polygon', a: a};
+};
+var $elm$json$Json$Decode$fail = _Json_fail;
+var $mgold$elm_geojson$GeoJson$decodePosition = function () {
+	var errorString = function (adj) {
+		return 'Array has too ' + (adj + ' numbers to make a position');
+	};
+	var listToTuple = function (ps) {
+		if (!ps.b) {
+			return $elm$json$Json$Decode$fail(
+				errorString('few'));
+		} else {
+			if (!ps.b.b) {
+				return $elm$json$Json$Decode$fail(
+					errorString('few'));
+			} else {
+				if (!ps.b.b.b) {
+					var p1 = ps.a;
+					var _v1 = ps.b;
+					var p2 = _v1.a;
+					return $elm$json$Json$Decode$succeed(
+						_Utils_Tuple3(p1, p2, 0));
+				} else {
+					if (!ps.b.b.b.b) {
+						var p1 = ps.a;
+						var _v2 = ps.b;
+						var p2 = _v2.a;
+						var _v3 = _v2.b;
+						var p3 = _v3.a;
+						return $elm$json$Json$Decode$succeed(
+							_Utils_Tuple3(p1, p2, p3));
+					} else {
+						return $elm$json$Json$Decode$fail(
+							errorString('many'));
+					}
+				}
+			}
+		}
+	};
+	return A2(
+		$elm$json$Json$Decode$andThen,
+		listToTuple,
+		$elm$json$Json$Decode$list($elm$json$Json$Decode$float));
+}();
+var $elm$json$Json$Decode$field = _Json_decodeField;
+var $elm$json$Json$Decode$string = _Json_decodeString;
+function $mgold$elm_geojson$GeoJson$cyclic$decodeGeometry() {
+	var helper = function (tipe) {
+		switch (tipe) {
+			case 'Point':
+				return A2(
+					$elm$json$Json$Decode$map,
+					$mgold$elm_geojson$GeoJson$Point,
+					A2($elm$json$Json$Decode$field, 'coordinates', $mgold$elm_geojson$GeoJson$decodePosition));
+			case 'MultiPoint':
+				return A2(
+					$elm$json$Json$Decode$map,
+					$mgold$elm_geojson$GeoJson$MultiPoint,
+					A2(
+						$elm$json$Json$Decode$field,
+						'coordinates',
+						$elm$json$Json$Decode$list($mgold$elm_geojson$GeoJson$decodePosition)));
+			case 'LineString':
+				return A2(
+					$elm$json$Json$Decode$map,
+					$mgold$elm_geojson$GeoJson$LineString,
+					A2(
+						$elm$json$Json$Decode$field,
+						'coordinates',
+						$elm$json$Json$Decode$list($mgold$elm_geojson$GeoJson$decodePosition)));
+			case 'MultiLineString':
+				return A2(
+					$elm$json$Json$Decode$map,
+					$mgold$elm_geojson$GeoJson$MultiLineString,
+					A2(
+						$elm$json$Json$Decode$field,
+						'coordinates',
+						$elm$json$Json$Decode$list(
+							$elm$json$Json$Decode$list($mgold$elm_geojson$GeoJson$decodePosition))));
+			case 'Polygon':
+				return A2(
+					$elm$json$Json$Decode$map,
+					$mgold$elm_geojson$GeoJson$Polygon,
+					A2(
+						$elm$json$Json$Decode$field,
+						'coordinates',
+						$elm$json$Json$Decode$list(
+							$elm$json$Json$Decode$list($mgold$elm_geojson$GeoJson$decodePosition))));
+			case 'MultiPolygon':
+				return A2(
+					$elm$json$Json$Decode$map,
+					$mgold$elm_geojson$GeoJson$MultiPolygon,
+					A2(
+						$elm$json$Json$Decode$field,
+						'coordinates',
+						$elm$json$Json$Decode$list(
+							$elm$json$Json$Decode$list(
+								$elm$json$Json$Decode$list($mgold$elm_geojson$GeoJson$decodePosition)))));
+			case 'GeometryCollection':
+				return A2(
+					$elm$json$Json$Decode$map,
+					$mgold$elm_geojson$GeoJson$GeometryCollection,
+					A2(
+						$elm$json$Json$Decode$field,
+						'geometries',
+						$elm$json$Json$Decode$list(
+							$mgold$elm_geojson$GeoJson$cyclic$decodeGeometry())));
+			default:
+				return $elm$json$Json$Decode$fail('Unrecognized \'type\': ' + tipe);
+		}
+	};
+	return A2(
+		$elm$json$Json$Decode$andThen,
+		helper,
+		A2($elm$json$Json$Decode$field, 'type', $elm$json$Json$Decode$string));
+}
+try {
+	var $mgold$elm_geojson$GeoJson$decodeGeometry = $mgold$elm_geojson$GeoJson$cyclic$decodeGeometry();
+	$mgold$elm_geojson$GeoJson$cyclic$decodeGeometry = function () {
+		return $mgold$elm_geojson$GeoJson$decodeGeometry;
+	};
+} catch ($) {
+	throw 'Some top-level definitions from `GeoJson` are causing infinite recursion:\n\n  ┌─────┐\n  │    decodeGeometry\n  └─────┘\n\nThese errors are very tricky, so read https://elm-lang.org/0.19.1/bad-recursion to learn how to fix it!';}
+var $elm$json$Json$Decode$int = _Json_decodeInt;
+var $elm$json$Json$Decode$map3 = _Json_map3;
+var $elm$json$Json$Decode$oneOf = _Json_oneOf;
+var $elm$json$Json$Decode$maybe = function (decoder) {
+	return $elm$json$Json$Decode$oneOf(
+		_List_fromArray(
+			[
+				A2($elm$json$Json$Decode$map, $elm$core$Maybe$Just, decoder),
+				$elm$json$Json$Decode$succeed($elm$core$Maybe$Nothing)
+			]));
+};
+var $elm$json$Json$Decode$null = _Json_decodeNull;
+var $elm$json$Json$Decode$value = _Json_decodeValue;
+var $mgold$elm_geojson$GeoJson$decodeFeature = A4(
+	$elm$json$Json$Decode$map3,
+	$mgold$elm_geojson$GeoJson$FeatureObject,
+	A2(
+		$elm$json$Json$Decode$field,
+		'geometry',
+		$elm$json$Json$Decode$oneOf(
+			_List_fromArray(
+				[
+					$elm$json$Json$Decode$null($elm$core$Maybe$Nothing),
+					A2($elm$json$Json$Decode$map, $elm$core$Maybe$Just, $mgold$elm_geojson$GeoJson$decodeGeometry)
+				]))),
+	A2($elm$json$Json$Decode$field, 'properties', $elm$json$Json$Decode$value),
+	$elm$json$Json$Decode$maybe(
+		A2(
+			$elm$json$Json$Decode$field,
+			'id',
+			$elm$json$Json$Decode$oneOf(
+				_List_fromArray(
+					[
+						$elm$json$Json$Decode$string,
+						A2($elm$json$Json$Decode$map, $elm$core$String$fromInt, $elm$json$Json$Decode$int)
+					])))));
+var $mgold$elm_geojson$GeoJson$decodeGeoJson = function () {
+	var helper = function (h_tipe) {
+		switch (h_tipe) {
+			case 'Feature':
+				return A2($elm$json$Json$Decode$map, $mgold$elm_geojson$GeoJson$Feature, $mgold$elm_geojson$GeoJson$decodeFeature);
+			case 'FeatureCollection':
+				return A2(
+					$elm$json$Json$Decode$map,
+					$mgold$elm_geojson$GeoJson$FeatureCollection,
+					A2(
+						$elm$json$Json$Decode$field,
+						'features',
+						$elm$json$Json$Decode$list($mgold$elm_geojson$GeoJson$decodeFeature)));
+			default:
+				return A2($elm$json$Json$Decode$map, $mgold$elm_geojson$GeoJson$Geometry, $mgold$elm_geojson$GeoJson$decodeGeometry);
+		}
+	};
+	return A2(
+		$elm$json$Json$Decode$andThen,
+		helper,
+		A2($elm$json$Json$Decode$field, 'type', $elm$json$Json$Decode$string));
+}();
+var $elm$core$Tuple$pair = F2(
+	function (a, b) {
+		return _Utils_Tuple2(a, b);
+	});
+var $mgold$elm_geojson$GeoJson$decoder = A3(
+	$elm$json$Json$Decode$map2,
+	$elm$core$Tuple$pair,
+	$mgold$elm_geojson$GeoJson$decodeGeoJson,
+	$elm$json$Json$Decode$maybe(
+		A2($elm$json$Json$Decode$field, 'bbox', $mgold$elm_geojson$GeoJson$decodeBbox)));
 var $elm$core$Dict$RBEmpty_elm_builtin = {$: 'RBEmpty_elm_builtin'};
 var $elm$core$Dict$empty = $elm$core$Dict$RBEmpty_elm_builtin;
 var $elm$core$Set$Set_elm_builtin = function (a) {
@@ -5721,10 +6137,251 @@ var $elm$core$Set$Set_elm_builtin = function (a) {
 var $elm$core$Set$empty = $elm$core$Set$Set_elm_builtin($elm$core$Dict$empty);
 var $author$project$Pages$ExecutionList$emptyExecutionListModel = {executionNameSearch: $elm$core$Maybe$Nothing, executions: _List_Nil, forTask: $elm$core$Maybe$Nothing, selectedExecutions: $elm$core$Set$empty};
 var $author$project$Pages$TaskList$emptyFormValues = {executionName: $elm$core$Maybe$Nothing, fromSchema: $elm$core$Dict$empty};
-var $author$project$Pages$TaskList$emptyTaskListModel = {activeSchema: $elm$core$Maybe$Nothing, formValues: $author$project$Pages$TaskList$emptyFormValues, selectedTask: $elm$core$Maybe$Nothing, taskValidationErrors: $elm$core$Dict$empty, tasks: _List_Nil};
+var $author$project$Pages$TaskList$emptyTaskListModel = {activeSchema: $elm$core$Maybe$Nothing, formValues: $author$project$Pages$TaskList$emptyFormValues, inputState: $elm$core$Maybe$Nothing, selectedTask: $elm$core$Maybe$Nothing, taskValidationErrors: $elm$core$Dict$empty, tasks: _List_Nil};
+var $elm$json$Json$Encode$float = _Json_wrap;
+var $elm$json$Json$Encode$list = F2(
+	function (func, entries) {
+		return _Json_wrap(
+			A3(
+				$elm$core$List$foldl,
+				_Json_addEntry(func),
+				_Json_emptyArray(_Utils_Tuple0),
+				entries));
+	});
+var $elm$core$Maybe$map = F2(
+	function (f, maybe) {
+		if (maybe.$ === 'Just') {
+			var value = maybe.a;
+			return $elm$core$Maybe$Just(
+				f(value));
+		} else {
+			return $elm$core$Maybe$Nothing;
+		}
+	});
+var $elm$core$Maybe$withDefault = F2(
+	function (_default, maybe) {
+		if (maybe.$ === 'Just') {
+			var value = maybe.a;
+			return value;
+		} else {
+			return _default;
+		}
+	});
+var $mgold$elm_geojson$GeoJson$encodeBbox = function (bbox) {
+	return A2(
+		$elm$core$Maybe$withDefault,
+		_List_Nil,
+		A2(
+			$elm$core$Maybe$map,
+			function (b) {
+				return _List_fromArray(
+					[
+						_Utils_Tuple2(
+						'bbox',
+						A2($elm$json$Json$Encode$list, $elm$json$Json$Encode$float, b))
+					]);
+			},
+			bbox));
+};
+var $elm$core$Basics$composeR = F3(
+	function (f, g, x) {
+		return g(
+			f(x));
+	});
+var $mgold$elm_geojson$GeoJson$encodePosition = function (_v0) {
+	var a = _v0.a;
+	var b = _v0.b;
+	var c = _v0.c;
+	var coordinates = (!c) ? _List_fromArray(
+		[a, b]) : _List_fromArray(
+		[a, b, c]);
+	return A2($elm$json$Json$Encode$list, $elm$json$Json$Encode$float, coordinates);
+};
+var $elm$json$Json$Encode$object = function (pairs) {
+	return _Json_wrap(
+		A3(
+			$elm$core$List$foldl,
+			F2(
+				function (_v0, obj) {
+					var k = _v0.a;
+					var v = _v0.b;
+					return A3(_Json_addField, k, v, obj);
+				}),
+			_Json_emptyObject(_Utils_Tuple0),
+			pairs));
+};
+var $elm$json$Json$Encode$string = _Json_wrap;
+var $mgold$elm_geojson$GeoJson$encodeGeometry = function (geom) {
+	switch (geom.$) {
+		case 'Point':
+			var data = geom.a;
+			return _List_fromArray(
+				[
+					_Utils_Tuple2(
+					'type',
+					$elm$json$Json$Encode$string('Point')),
+					_Utils_Tuple2(
+					'coordinates',
+					$mgold$elm_geojson$GeoJson$encodePosition(data))
+				]);
+		case 'MultiPoint':
+			var data = geom.a;
+			return _List_fromArray(
+				[
+					_Utils_Tuple2(
+					'type',
+					$elm$json$Json$Encode$string('MultiPoint')),
+					_Utils_Tuple2(
+					'coordinates',
+					A2($elm$json$Json$Encode$list, $mgold$elm_geojson$GeoJson$encodePosition, data))
+				]);
+		case 'LineString':
+			var data = geom.a;
+			return _List_fromArray(
+				[
+					_Utils_Tuple2(
+					'type',
+					$elm$json$Json$Encode$string('LineString')),
+					_Utils_Tuple2(
+					'coordinates',
+					A2($elm$json$Json$Encode$list, $mgold$elm_geojson$GeoJson$encodePosition, data))
+				]);
+		case 'MultiLineString':
+			var data = geom.a;
+			return _List_fromArray(
+				[
+					_Utils_Tuple2(
+					'type',
+					$elm$json$Json$Encode$string('MultiLineString')),
+					_Utils_Tuple2(
+					'coordinates',
+					A2(
+						$elm$json$Json$Encode$list,
+						$elm$json$Json$Encode$list($mgold$elm_geojson$GeoJson$encodePosition),
+						data))
+				]);
+		case 'Polygon':
+			var data = geom.a;
+			return _List_fromArray(
+				[
+					_Utils_Tuple2(
+					'type',
+					$elm$json$Json$Encode$string('Polygon')),
+					_Utils_Tuple2(
+					'coordinates',
+					A2(
+						$elm$json$Json$Encode$list,
+						$elm$json$Json$Encode$list($mgold$elm_geojson$GeoJson$encodePosition),
+						data))
+				]);
+		case 'MultiPolygon':
+			var data = geom.a;
+			return _List_fromArray(
+				[
+					_Utils_Tuple2(
+					'type',
+					$elm$json$Json$Encode$string('MultiPolygon')),
+					_Utils_Tuple2(
+					'coordinates',
+					A2(
+						$elm$json$Json$Encode$list,
+						$elm$json$Json$Encode$list(
+							$elm$json$Json$Encode$list($mgold$elm_geojson$GeoJson$encodePosition)),
+						data))
+				]);
+		default:
+			var data = geom.a;
+			return _List_fromArray(
+				[
+					_Utils_Tuple2(
+					'type',
+					$elm$json$Json$Encode$string('GeometryCollection')),
+					_Utils_Tuple2(
+					'geometries',
+					A2(
+						$elm$json$Json$Encode$list,
+						A2($elm$core$Basics$composeR, $mgold$elm_geojson$GeoJson$encodeGeometry, $elm$json$Json$Encode$object),
+						data))
+				]);
+	}
+};
+var $elm$json$Json$Encode$null = _Json_encodeNull;
+var $mgold$elm_geojson$GeoJson$encodeFeature = function (_v0) {
+	var geometry = _v0.geometry;
+	var properties = _v0.properties;
+	var id = _v0.id;
+	var encodedId = function () {
+		if (id.$ === 'Nothing') {
+			return _List_Nil;
+		} else {
+			var theId = id.a;
+			return _List_fromArray(
+				[
+					_Utils_Tuple2(
+					'id',
+					$elm$json$Json$Encode$string(theId))
+				]);
+		}
+	}();
+	return _Utils_ap(
+		_List_fromArray(
+			[
+				_Utils_Tuple2(
+				'type',
+				$elm$json$Json$Encode$string('Feature')),
+				_Utils_Tuple2(
+				'geometry',
+				A2(
+					$elm$core$Maybe$withDefault,
+					$elm$json$Json$Encode$null,
+					A2(
+						$elm$core$Maybe$map,
+						A2($elm$core$Basics$composeR, $mgold$elm_geojson$GeoJson$encodeGeometry, $elm$json$Json$Encode$object),
+						geometry))),
+				_Utils_Tuple2('properties', properties)
+			]),
+		encodedId);
+};
+var $mgold$elm_geojson$GeoJson$encodeGeoJson = function (geojson) {
+	switch (geojson.$) {
+		case 'Feature':
+			var feature = geojson.a;
+			return $mgold$elm_geojson$GeoJson$encodeFeature(feature);
+		case 'FeatureCollection':
+			var features = geojson.a;
+			return _List_fromArray(
+				[
+					_Utils_Tuple2(
+					'type',
+					$elm$json$Json$Encode$string('FeatureCollection')),
+					_Utils_Tuple2(
+					'features',
+					A2(
+						$elm$json$Json$Encode$list,
+						A2($elm$core$Basics$composeR, $mgold$elm_geojson$GeoJson$encodeFeature, $elm$json$Json$Encode$object),
+						features))
+				]);
+		default:
+			var geometry = geojson.a;
+			return $mgold$elm_geojson$GeoJson$encodeGeometry(geometry);
+	}
+};
+var $mgold$elm_geojson$GeoJson$encode = function (_v0) {
+	var geojson = _v0.a;
+	var bbox = _v0.b;
+	return $elm$json$Json$Encode$object(
+		_Utils_ap(
+			$mgold$elm_geojson$GeoJson$encodeGeoJson(geojson),
+			$mgold$elm_geojson$GeoJson$encodeBbox(bbox)));
+};
 var $author$project$Types$GotExecutions = F2(
 	function (a, b) {
 		return {$: 'GotExecutions', a: a, b: b};
+	});
+var $elm$core$Basics$composeL = F3(
+	function (g, f, x) {
+		return g(
+			f(x));
 	});
 var $elm$core$String$concat = function (strings) {
 	return A2($elm$core$String$join, '', strings);
@@ -5765,16 +6422,6 @@ var $elm$core$List$intersperse = F2(
 			return A2($elm$core$List$cons, hd, spersed);
 		}
 	});
-var $elm$core$Maybe$map = F2(
-	function (f, maybe) {
-		if (maybe.$ === 'Just') {
-			var value = maybe.a;
-			return $elm$core$Maybe$Just(
-				f(value));
-		} else {
-			return $elm$core$Maybe$Nothing;
-		}
-	});
 var $danyx23$elm_uuid$Uuid$toString = function (_v0) {
 	var internalString = _v0.a;
 	return internalString;
@@ -5808,13 +6455,10 @@ var $author$project$Urls$apiExecutionsUrl = F2(
 	function (namesLike, taskId) {
 		return '/api' + A2($author$project$Urls$executionsUrl, namesLike, taskId);
 	});
-var $author$project$Main$GranaryExecution = F7(
+var $author$project$Types$GranaryExecution = F7(
 	function (id, taskId, invokedAt, statusReason, results, webhookId, name) {
 		return {id: id, invokedAt: invokedAt, name: name, results: results, statusReason: statusReason, taskId: taskId, webhookId: webhookId};
 	});
-var $elm$json$Json$Decode$andThen = _Json_andThen;
-var $elm$json$Json$Decode$fail = _Json_fail;
-var $elm$json$Json$Decode$string = _Json_decodeString;
 var $elm$parser$Parser$Advanced$Bad = F2(
 	function (a, b) {
 		return {$: 'Bad', a: a, b: b};
@@ -6606,15 +7250,6 @@ var $elm$regex$Regex$fromString = function (string) {
 		string);
 };
 var $elm$regex$Regex$never = _Regex_never;
-var $elm$core$Maybe$withDefault = F2(
-	function (_default, maybe) {
-		if (maybe.$ === 'Just') {
-			var value = maybe.a;
-			return value;
-		} else {
-			return _default;
-		}
-	});
 var $danyx23$elm_uuid$Uuid$Barebones$uuidRegex = A2(
 	$elm$core$Maybe$withDefault,
 	$elm$regex$Regex$never,
@@ -6640,25 +7275,14 @@ var $danyx23$elm_uuid$Uuid$decoder = A2(
 		}
 	},
 	$elm$json$Json$Decode$string);
-var $author$project$Main$StacAsset = F5(
+var $author$project$Types$StacAsset = F5(
 	function (href, title, description, roles, mediaType) {
 		return {description: description, href: href, mediaType: mediaType, roles: roles, title: title};
 	});
-var $elm$json$Json$Decode$field = _Json_decodeField;
-var $elm$json$Json$Decode$list = _Json_decodeList;
 var $elm$json$Json$Decode$map5 = _Json_map5;
-var $elm$json$Json$Decode$oneOf = _Json_oneOf;
-var $elm$json$Json$Decode$maybe = function (decoder) {
-	return $elm$json$Json$Decode$oneOf(
-		_List_fromArray(
-			[
-				A2($elm$json$Json$Decode$map, $elm$core$Maybe$Just, decoder),
-				$elm$json$Json$Decode$succeed($elm$core$Maybe$Nothing)
-			]));
-};
 var $author$project$Main$decoderStacAsset = A6(
 	$elm$json$Json$Decode$map5,
-	$author$project$Main$StacAsset,
+	$author$project$Types$StacAsset,
 	A2($elm$json$Json$Decode$field, 'href', $elm$json$Json$Decode$string),
 	A2(
 		$elm$json$Json$Decode$field,
@@ -6676,7 +7300,7 @@ var $author$project$Main$decoderStacAsset = A6(
 var $elm$json$Json$Decode$map7 = _Json_map7;
 var $author$project$Main$decoderGranaryExecution = A8(
 	$elm$json$Json$Decode$map7,
-	$author$project$Main$GranaryExecution,
+	$author$project$Types$GranaryExecution,
 	A2($elm$json$Json$Decode$field, 'id', $danyx23$elm_uuid$Uuid$decoder),
 	A2($elm$json$Json$Decode$field, 'taskId', $danyx23$elm_uuid$Uuid$decoder),
 	A2($elm$json$Json$Decode$field, 'invokedAt', $elm_community$json_extra$Json$Decode$Extra$datetime),
@@ -6693,7 +7317,6 @@ var $author$project$Main$decoderGranaryExecution = A8(
 		'webhookId',
 		$elm$json$Json$Decode$maybe($danyx23$elm_uuid$Uuid$decoder)),
 	A2($elm$json$Json$Decode$field, 'name', $elm$json$Json$Decode$string));
-var $elm$json$Json$Decode$decodeString = _Json_runOnString;
 var $elm$http$Http$BadStatus_ = F2(
 	function (a, b) {
 		return {$: 'BadStatus_', a: a, b: b};
@@ -7234,11 +7857,6 @@ var $elm$core$Dict$update = F3(
 			return A2($elm$core$Dict$remove, targetKey, dictionary);
 		}
 	});
-var $elm$core$Basics$composeR = F3(
-	function (f, g, x) {
-		return g(
-			f(x));
-	});
 var $elm$http$Http$expectStringResponse = F2(
 	function (toMsg, toResult) {
 		return A3(
@@ -7332,8 +7950,6 @@ var $author$project$Types$PaginatedResponse = F3(
 	function (page, limit, results) {
 		return {limit: limit, page: page, results: results};
 	});
-var $elm$json$Json$Decode$int = _Json_decodeInt;
-var $elm$json$Json$Decode$map3 = _Json_map3;
 var $author$project$Main$paginatedDecoder = function (ofDecoder) {
 	return A4(
 		$elm$json$Json$Decode$map3,
@@ -7665,7 +8281,6 @@ var $elm$core$List$isEmpty = function (xs) {
 var $1602$json_schema$Json$Schema$Definitions$failIfEmpty = function (l) {
 	return $elm$core$List$isEmpty(l) ? $elm$json$Json$Decode$fail('List is empty') : $elm$json$Json$Decode$succeed(l);
 };
-var $elm$json$Json$Decode$float = _Json_decodeFloat;
 var $elm$json$Json$Decode$keyValuePairs = _Json_decodeKeyValuePairs;
 var $elm$json$Json$Decode$lazy = function (thunk) {
 	return A2(
@@ -7823,7 +8438,6 @@ var $1602$json_schema$Json$Schema$Definitions$multipleTypesDecoder = function (l
 var $1602$json_schema$Json$Schema$Definitions$failIfValuesAreNotUnique = function (l) {
 	return $elm$json$Json$Decode$succeed(l);
 };
-var $elm$json$Json$Decode$value = _Json_decodeValue;
 var $1602$json_schema$Json$Schema$Definitions$nonEmptyUniqueArrayOfValuesDecoder = A2(
 	$elm$json$Json$Decode$andThen,
 	$1602$json_schema$Json$Schema$Definitions$failIfEmpty,
@@ -7838,7 +8452,6 @@ var $1602$json_schema$Json$Schema$Definitions$nonNegativeInt = A2(
 		return (x >= 0) ? $elm$json$Json$Decode$succeed(x) : $elm$json$Json$Decode$fail('Expected non-negative int');
 	},
 	$elm$json$Json$Decode$int);
-var $elm$json$Json$Decode$null = _Json_decodeNull;
 var $elm$json$Json$Decode$nullable = function (decoder) {
 	return $elm$json$Json$Decode$oneOf(
 		_List_fromArray(
@@ -8292,6 +8905,44 @@ var $author$project$Main$fetchTasks = function (token) {
 					$author$project$Main$paginatedDecoder($author$project$Pages$TaskList$decoderGranaryTask)),
 				$lukewestby$elm_http_builder$HttpBuilder$get('/api/tasks'))));
 };
+var $elm$file$File$Select$files = F2(
+	function (mimes, toMsg) {
+		return A2(
+			$elm$core$Task$perform,
+			function (_v0) {
+				var f = _v0.a;
+				var fs = _v0.b;
+				return A2(toMsg, f, fs);
+			},
+			_File_uploadOneOrMore(mimes));
+	});
+var $author$project$Main$getSelectedExecutions = function (model) {
+	var _v0 = model.route;
+	if (_v0.$ === 'ExecutionList') {
+		var elm = _v0.a;
+		return $elm$core$Maybe$Just(elm.selectedExecutions);
+	} else {
+		return $elm$core$Maybe$Nothing;
+	}
+};
+var $author$project$Main$getSelectedTask = function (model) {
+	var _v0 = model.route;
+	switch (_v0.$) {
+		case 'TaskList':
+			var tlm = _v0.a;
+			return A2(
+				$elm$core$Maybe$map,
+				function ($) {
+					return $.id;
+				},
+				tlm.selectedTask);
+		case 'ExecutionList':
+			var elm = _v0.a;
+			return elm.forTask;
+		default:
+			return $elm$core$Maybe$Nothing;
+	}
+};
 var $elm$core$Set$insert = F2(
 	function (key, _v0) {
 		var dict = _v0.a;
@@ -8304,21 +8955,7 @@ var $elm$core$Platform$Cmd$none = $elm$core$Platform$Cmd$batch(_List_Nil);
 var $author$project$Types$CreatedExecution = function (a) {
 	return {$: 'CreatedExecution', a: a};
 };
-var $elm$json$Json$Encode$string = _Json_wrap;
 var $danyx23$elm_uuid$Uuid$encode = A2($elm$core$Basics$composeR, $danyx23$elm_uuid$Uuid$toString, $elm$json$Json$Encode$string);
-var $elm$json$Json$Encode$object = function (pairs) {
-	return _Json_wrap(
-		A3(
-			$elm$core$List$foldl,
-			F2(
-				function (_v0, obj) {
-					var k = _v0.a;
-					var v = _v0.b;
-					return A3(_Json_addField, k, v, obj);
-				}),
-			_Json_emptyObject(_Utils_Tuple0),
-			pairs));
-};
 var $author$project$Main$encodeExecutionCreate = function (executionCreate) {
 	return $elm$json$Json$Encode$object(
 		_List_fromArray(
@@ -8679,17 +9316,30 @@ var $author$project$Main$routeParser = function () {
 			[
 				A2(
 				$elm$url$Url$Parser$map,
-				$author$project$Main$ExecutionList,
+				function (maybeId) {
+					return $author$project$Main$ExecutionList(
+						_Utils_update(
+							$author$project$Pages$ExecutionList$emptyExecutionListModel,
+							{forTask: maybeId}));
+				},
 				A2(
 					$elm$url$Url$Parser$questionMark,
 					$elm$url$Url$Parser$s('executions'),
 					A2($elm$url$Url$Parser$Query$custom, 'taskId', uuidQueryParam))),
 				A2(
 				$elm$url$Url$Parser$map,
-				$author$project$Main$TaskList,
+				$author$project$Main$TaskList($author$project$Pages$TaskList$emptyTaskListModel),
 				$elm$url$Url$Parser$s('tasks'))
 			]));
 }();
+var $author$project$Pages$TaskList$setInputState = F2(
+	function (event, model) {
+		return _Utils_update(
+			model,
+			{
+				inputState: $elm$core$Maybe$Just(event)
+			});
+	});
 var $author$project$Pages$TaskList$showType = function (t) {
 	switch (t.$) {
 		case 'SingleType':
@@ -8741,6 +9391,7 @@ var $elm$core$Dict$singleton = F2(
 	function (key, value) {
 		return A5($elm$core$Dict$RBNode_elm_builtin, $elm$core$Dict$Black, key, value, $elm$core$Dict$RBEmpty_elm_builtin, $elm$core$Dict$RBEmpty_elm_builtin);
 	});
+var $elm$file$File$toString = _File_toString;
 var $elm$core$Dict$foldl = F3(
 	function (func, acc, dict) {
 		foldl:
@@ -8771,20 +9422,24 @@ var $elm$core$Dict$union = F2(
 		return A3($elm$core$Dict$foldl, $elm$core$Dict$insert, t2, t1);
 	});
 var $author$project$Main$updateExecutionListModel = F2(
-	function (f, mod) {
-		var baseExecutionListModel = mod.executionListModel;
-		var updated = A2($elm$core$Maybe$map, f, baseExecutionListModel);
-		return _Utils_update(
-			mod,
-			{executionListModel: updated});
+	function (f, route) {
+		if (route.$ === 'ExecutionList') {
+			var mod = route.a;
+			return $elm$core$Maybe$Just(
+				f(mod));
+		} else {
+			return $elm$core$Maybe$Nothing;
+		}
 	});
 var $author$project$Main$updateTaskListModel = F2(
-	function (f, mod) {
-		var baseTaskListModel = mod.taskListModel;
-		var updated = A2($elm$core$Maybe$map, f, baseTaskListModel);
-		return _Utils_update(
-			mod,
-			{taskListModel: updated});
+	function (f, route) {
+		if (route.$ === 'TaskList') {
+			var mod = route.a;
+			return $elm$core$Maybe$Just(
+				f(mod));
+		} else {
+			return $elm$core$Maybe$Nothing;
+		}
 	});
 var $elm$core$List$filter = F2(
 	function (isGood, list) {
@@ -10814,19 +11469,18 @@ var $author$project$Main$update = F2(
 										}
 									}
 								}
-								var _v3 = _v1.b;
+								var _v2 = _v1.b;
 								return $elm$core$Platform$Cmd$none;
 							}
 							return A2($elm$browser$Browser$Navigation$pushUrl, model.key, '/tasks');
 						}
-						var taskId = _v1.a.a.a;
+						var elm = _v1.a.a.a;
 						var modelToken = _v1.b;
 						return A2(
 							getCmd,
-							A2($author$project$Main$fetchExecutions, $elm$core$Maybe$Nothing, taskId),
+							A2($author$project$Main$fetchExecutions, $elm$core$Maybe$Nothing, elm.forTask),
 							modelToken);
 					}
-					var _v2 = _v1.a.a;
 					var modelToken = _v1.b;
 					return A2(getCmd, $author$project$Main$fetchTasks, modelToken);
 				}();
@@ -10853,34 +11507,42 @@ var $author$project$Main$update = F2(
 				}
 			case 'TaskSelect':
 				var task = msg.a;
-				return _Utils_Tuple2(
+				var newRoute = A2(
+					$elm$core$Maybe$withDefault,
+					$author$project$Main$Login,
 					A2(
-						$author$project$Main$updateTaskListModel,
-						function (tlm) {
-							return _Utils_update(
-								tlm,
-								{
-									activeSchema: $elm$core$Maybe$Just(task.validator),
-									formValues: $author$project$Pages$TaskList$emptyFormValues,
-									selectedTask: $elm$core$Maybe$Just(task),
-									taskValidationErrors: $elm$core$Dict$empty
-								});
-						},
-						model),
+						$elm$core$Maybe$map,
+						$author$project$Main$TaskList,
+						A2(
+							$author$project$Main$updateTaskListModel,
+							function (tlm) {
+								return _Utils_update(
+									tlm,
+									{
+										activeSchema: $elm$core$Maybe$Just(task.validator),
+										formValues: $author$project$Pages$TaskList$emptyFormValues,
+										selectedTask: $elm$core$Maybe$Just(task),
+										taskValidationErrors: $elm$core$Dict$empty
+									});
+							},
+							model.route)));
+				return _Utils_Tuple2(
+					_Utils_update(
+						model,
+						{route: newRoute}),
 					$elm$core$Platform$Cmd$none);
 			case 'GotTasks':
 				if (msg.a.$ === 'Ok') {
 					var tasks = msg.a.a;
-					var withTasks = _Utils_update(
-						$author$project$Pages$TaskList$emptyTaskListModel,
-						{tasks: tasks.results});
 					return _Utils_Tuple2(
 						_Utils_update(
 							model,
 							{
-								route: $author$project$Main$TaskList,
-								secretsUnsubmitted: $elm$core$Maybe$Nothing,
-								taskListModel: $elm$core$Maybe$Just(withTasks)
+								route: $author$project$Main$TaskList(
+									_Utils_update(
+										$author$project$Pages$TaskList$emptyTaskListModel,
+										{tasks: tasks.results})),
+								secretsUnsubmitted: $elm$core$Maybe$Nothing
 							}),
 						$elm$core$Platform$Cmd$none);
 				} else {
@@ -10890,26 +11552,16 @@ var $author$project$Main$update = F2(
 				if (msg.b.$ === 'Ok') {
 					var taskId = msg.a;
 					var executionsPage = msg.b.a;
-					var withExecutions = A2(
-						$elm$core$Maybe$withDefault,
-						_Utils_update(
-							$author$project$Pages$ExecutionList$emptyExecutionListModel,
-							{executions: executionsPage.results, forTask: taskId}),
-						A2(
-							$elm$core$Maybe$map,
-							function (elm) {
-								return _Utils_update(
-									elm,
-									{executions: executionsPage.results, forTask: taskId});
-							},
-							model.executionListModel));
+					var withExecutions = function (elm) {
+						return _Utils_update(
+							elm,
+							{executions: executionsPage.results, forTask: taskId});
+					}($author$project$Pages$ExecutionList$emptyExecutionListModel);
 					return _Utils_Tuple2(
 						_Utils_update(
 							model,
 							{
-								executionListModel: $elm$core$Maybe$Just(withExecutions),
-								route: $author$project$Main$ExecutionList(taskId),
-								taskListModel: $elm$core$Maybe$Nothing
+								route: $author$project$Main$ExecutionList(withExecutions)
 							}),
 						$elm$core$Platform$Cmd$none);
 				} else {
@@ -10944,27 +11596,17 @@ var $author$project$Main$update = F2(
 								'',
 								A2(
 									$elm$core$Maybe$map,
-									A2(
-										$elm$core$Basics$composeL,
-										$danyx23$elm_uuid$Uuid$toString,
-										function ($) {
-											return $.id;
-										}),
-									A2(
-										$elm$core$Maybe$andThen,
-										function ($) {
-											return $.selectedTask;
-										},
-										model.taskListModel)))));
+									$danyx23$elm_uuid$Uuid$toString,
+									$author$project$Main$getSelectedTask(model)))));
 				} else {
 					return _Utils_Tuple2(model, $elm$core$Platform$Cmd$none);
 				}
 			case 'ValidateWith':
 				var validateOpts = msg.a;
 				var validation = function () {
-					var _v6 = validateOpts.fieldValue;
-					if (_v6.$ === 'Ok') {
-						var jsonValue = _v6.a;
+					var _v5 = validateOpts.fieldValue;
+					if (_v5.$ === 'Ok') {
+						var jsonValue = _v5.a;
 						return A3(
 							$1602$json_schema$Json$Schema$validateValue,
 							{applyDefaults: true},
@@ -10986,80 +11628,76 @@ var $author$project$Main$update = F2(
 								]));
 					}
 				}();
-				if (validation.$ === 'Ok') {
-					var formValues = A2(
-						$elm$core$Maybe$withDefault,
-						$author$project$Pages$TaskList$emptyFormValues,
-						A2(
-							$elm$core$Maybe$map,
-							function ($) {
-								return $.formValues;
-							},
-							model.taskListModel));
-					var newFormValues = _Utils_update(
-						formValues,
-						{
-							fromSchema: A2(
-								$elm$core$Dict$union,
-								A2($elm$core$Dict$singleton, validateOpts.fieldName, validateOpts.fieldValue),
-								formValues.fromSchema)
-						});
-					var baseValidationErrors = A2(
-						$elm$core$Maybe$withDefault,
-						$elm$core$Dict$empty,
-						A2(
-							$elm$core$Maybe$map,
-							function ($) {
-								return $.taskValidationErrors;
-							},
-							model.taskListModel));
-					var updatedTlm = A2(
-						$author$project$Main$updateTaskListModel,
-						function (tlm) {
-							return _Utils_update(
+				var _v4 = _Utils_Tuple2(validation, model.route);
+				_v4$2:
+				while (true) {
+					if (_v4.a.$ === 'Ok') {
+						if (_v4.b.$ === 'TaskList') {
+							var tlm = _v4.b.a;
+							var formValues = tlm.formValues;
+							var newFormValues = _Utils_update(
+								formValues,
+								{
+									fromSchema: A2(
+										$elm$core$Dict$union,
+										A2($elm$core$Dict$singleton, validateOpts.fieldName, validateOpts.fieldValue),
+										formValues.fromSchema)
+								});
+							var baseValidationErrors = tlm.taskValidationErrors;
+							var updatedTlm = _Utils_update(
 								tlm,
 								{
 									formValues: newFormValues,
 									taskValidationErrors: A2($elm$core$Dict$remove, validateOpts.fieldName, baseValidationErrors)
 								});
-						},
-						model);
-					return _Utils_Tuple2(updatedTlm, $elm$core$Platform$Cmd$none);
-				} else {
-					var errs = validation.a;
-					var formValues = A2(
-						$elm$core$Maybe$withDefault,
-						$author$project$Pages$TaskList$emptyFormValues,
-						A2(
-							$elm$core$Maybe$map,
-							function ($) {
-								return $.formValues;
-							},
-							model.taskListModel));
-					var newFormValues = _Utils_update(
-						formValues,
-						{
-							fromSchema: A2(
-								$elm$core$Dict$union,
-								A2($elm$core$Dict$singleton, validateOpts.fieldName, validateOpts.fieldValue),
-								formValues.fromSchema)
-						});
-					var updatedTlm = A2(
-						$author$project$Main$updateTaskListModel,
-						function (tlm) {
-							return _Utils_update(
+							return _Utils_Tuple2(
+								_Utils_update(
+									model,
+									{
+										route: $author$project$Main$TaskList(updatedTlm)
+									}),
+								$elm$core$Platform$Cmd$none);
+						} else {
+							break _v4$2;
+						}
+					} else {
+						if (_v4.b.$ === 'TaskList') {
+							var errs = _v4.a.a;
+							var tlm = _v4.b.a;
+							var formValues = tlm.formValues;
+							var newFormValues = _Utils_update(
+								formValues,
+								{
+									fromSchema: A2(
+										$elm$core$Dict$union,
+										A2($elm$core$Dict$singleton, validateOpts.fieldName, validateOpts.fieldValue),
+										formValues.fromSchema)
+								});
+							var updatedTlm = _Utils_update(
 								tlm,
 								{
 									formValues: newFormValues,
 									taskValidationErrors: A2(
 										$elm$core$Dict$union,
-										A2($elm$core$Dict$singleton, validateOpts.fieldName, errs),
+										A2(
+											$elm$core$Dict$singleton,
+											validateOpts.fieldName,
+											$author$project$Types$SchemaError(errs)),
 										tlm.taskValidationErrors)
 								});
-						},
-						model);
-					return _Utils_Tuple2(updatedTlm, $elm$core$Platform$Cmd$none);
+							return _Utils_Tuple2(
+								_Utils_update(
+									model,
+									{
+										route: $author$project$Main$TaskList(updatedTlm)
+									}),
+								$elm$core$Platform$Cmd$none);
+						} else {
+							break _v4$2;
+						}
+					}
 				}
+				return _Utils_Tuple2(model, $elm$core$Platform$Cmd$none);
 			case 'CreateExecution':
 				var executionCreate = msg.a;
 				return _Utils_Tuple2(
@@ -11071,22 +11709,27 @@ var $author$project$Main$update = F2(
 				var selectedExecutions = A2(
 					$elm$core$Maybe$withDefault,
 					$elm$core$Set$empty,
-					A2(
-						$elm$core$Maybe$map,
-						function ($) {
-							return $.selectedExecutions;
-						},
-						model.executionListModel));
+					$author$project$Main$getSelectedExecutions(model));
 				var newSelected = A2($elm$core$Set$member, stringExecutionId, selectedExecutions) ? A2($elm$core$Set$remove, stringExecutionId, selectedExecutions) : A2($elm$core$Set$insert, stringExecutionId, selectedExecutions);
 				var updatedElm = A2(
-					$author$project$Main$updateExecutionListModel,
-					function (elm) {
-						return _Utils_update(
-							elm,
-							{selectedExecutions: newSelected});
-					},
-					model);
-				return _Utils_Tuple2(updatedElm, $elm$core$Platform$Cmd$none);
+					$elm$core$Maybe$withDefault,
+					$author$project$Main$Login,
+					A2(
+						$elm$core$Maybe$map,
+						$author$project$Main$ExecutionList,
+						A2(
+							$author$project$Main$updateExecutionListModel,
+							function (elm) {
+								return _Utils_update(
+									elm,
+									{selectedExecutions: newSelected});
+							},
+							model.route)));
+				return _Utils_Tuple2(
+					_Utils_update(
+						model,
+						{route: updatedElm}),
+					$elm$core$Platform$Cmd$none);
 			case 'SearchExecutionName':
 				var s = msg.a;
 				var updatedElm = A2(
@@ -11098,9 +11741,15 @@ var $author$project$Main$update = F2(
 								executionNameSearch: $elm$core$Maybe$Just(s)
 							});
 					},
-					model);
+					model.route);
+				var newRoute = A2(
+					$elm$core$Maybe$withDefault,
+					$author$project$Main$Login,
+					A2($elm$core$Maybe$map, $author$project$Main$ExecutionList, updatedElm));
 				return _Utils_Tuple2(
-					updatedElm,
+					_Utils_update(
+						model,
+						{route: newRoute}),
 					A2(
 						$elm$core$Maybe$withDefault,
 						$elm$core$Platform$Cmd$none,
@@ -11114,7 +11763,7 @@ var $author$project$Main$update = F2(
 									function ($) {
 										return $.forTask;
 									},
-									model.executionListModel)),
+									updatedElm)),
 							model.secrets)));
 			case 'AddTokenParam':
 				var token = msg.a;
@@ -11127,11 +11776,11 @@ var $author$project$Main$update = F2(
 				var isEmpty = $elm$core$String$isEmpty(
 					A2($elm$core$Maybe$withDefault, '', baseUrl.query));
 				var newQp = function () {
-					var _v7 = _Utils_Tuple2(hasToken, isEmpty);
-					if (_v7.a) {
+					var _v6 = _Utils_Tuple2(hasToken, isEmpty);
+					if (_v6.a) {
 						return A2($elm$core$Maybe$withDefault, '', baseUrl.query);
 					} else {
-						if (!_v7.b) {
+						if (!_v6.b) {
 							return _Utils_ap(
 								A2($elm$core$Maybe$withDefault, '', baseUrl.query) + '&',
 								tokenQp);
@@ -11155,33 +11804,174 @@ var $author$project$Main$update = F2(
 				return _Utils_Tuple2(
 					_Utils_update(
 						model,
-						{taskListModel: $elm$core$Maybe$Nothing}),
+						{route: $author$project$Main$Login}),
 					A2($elm$browser$Browser$Navigation$pushUrl, model.key, '/tasks'));
-			default:
+			case 'NameExecution':
 				var s = msg.a;
-				var formValues = A2(
-					$elm$core$Maybe$withDefault,
-					$author$project$Pages$TaskList$emptyFormValues,
-					A2(
-						$elm$core$Maybe$map,
-						function ($) {
-							return $.formValues;
-						},
-						model.taskListModel));
+				var formValues = function () {
+					var _v7 = model.route;
+					if (_v7.$ === 'TaskList') {
+						var tlm = _v7.a;
+						return tlm.formValues;
+					} else {
+						return $author$project$Pages$TaskList$emptyFormValues;
+					}
+				}();
 				var newFormValues = _Utils_update(
 					formValues,
 					{
 						executionName: $elm$core$Maybe$Just(s)
 					});
 				var updatedTlm = A2(
-					$author$project$Main$updateTaskListModel,
-					function (tlm) {
-						return _Utils_update(
+					$elm$core$Maybe$withDefault,
+					$author$project$Main$Login,
+					A2(
+						$elm$core$Maybe$map,
+						$author$project$Main$TaskList,
+						A2(
+							$author$project$Main$updateTaskListModel,
+							function (tlm) {
+								return _Utils_update(
+									tlm,
+									{formValues: newFormValues});
+							},
+							model.route)));
+				return _Utils_Tuple2(
+					_Utils_update(
+						model,
+						{route: updatedTlm}),
+					$elm$core$Platform$Cmd$none);
+			case 'GotFiles':
+				var head = msg.a;
+				return _Utils_Tuple2(
+					model,
+					A2(
+						$elm$core$Task$perform,
+						$author$project$Types$GeoJsonData,
+						$elm$file$File$toString(head)));
+			case 'GeoJsonData':
+				var data = msg.a;
+				var _v8 = _Utils_Tuple2(
+					A2($elm$json$Json$Decode$decodeString, $mgold$elm_geojson$GeoJson$decoder, data),
+					model.route);
+				if (_v8.a.$ === 'Ok') {
+					if (_v8.b.$ === 'TaskList') {
+						var taskGrid = _v8.a.a;
+						var tlm = _v8.b.a;
+						var formValues = tlm.formValues;
+						var addition = A2(
+							$elm$core$Dict$singleton,
+							'TASK_GRID',
+							$elm$core$Result$Ok(
+								$mgold$elm_geojson$GeoJson$encode(taskGrid)));
+						var newFormValues = _Utils_update(
+							formValues,
+							{
+								fromSchema: A2($elm$core$Dict$union, addition, formValues.fromSchema)
+							});
+						var updated = _Utils_update(
 							tlm,
 							{formValues: newFormValues});
-					},
-					model);
-				return _Utils_Tuple2(updatedTlm, $elm$core$Platform$Cmd$none);
+						return _Utils_Tuple2(
+							_Utils_update(
+								model,
+								{
+									route: $author$project$Main$TaskList(updated)
+								}),
+							$elm$core$Platform$Cmd$none);
+					} else {
+						var taskGrid = _v8.a.a;
+						var formValues = _Utils_update(
+							$author$project$Pages$TaskList$emptyFormValues,
+							{
+								fromSchema: A2(
+									$elm$core$Dict$singleton,
+									'TASK_GRID',
+									$elm$core$Result$Ok(
+										$mgold$elm_geojson$GeoJson$encode(taskGrid)))
+							});
+						return _Utils_Tuple2(
+							_Utils_update(
+								model,
+								{
+									route: $author$project$Main$TaskList(
+										_Utils_update(
+											$author$project$Pages$TaskList$emptyTaskListModel,
+											{formValues: formValues}))
+								}),
+							$elm$core$Platform$Cmd$none);
+					}
+				} else {
+					if (_v8.b.$ === 'TaskList') {
+						var err = _v8.a.a;
+						var tlm = _v8.b.a;
+						var validationErrors = tlm.taskValidationErrors;
+						var addition = A2(
+							$elm$core$Dict$singleton,
+							'TASK_GRID',
+							$author$project$Types$DecodingError(err));
+						var updated = _Utils_update(
+							tlm,
+							{
+								taskValidationErrors: A2($elm$core$Dict$union, addition, validationErrors)
+							});
+						return _Utils_Tuple2(
+							_Utils_update(
+								model,
+								{
+									route: $author$project$Main$TaskList(updated)
+								}),
+							$elm$core$Platform$Cmd$none);
+					} else {
+						var err = _v8.a.a;
+						var validationErrors = A2(
+							$elm$core$Dict$singleton,
+							'TASK_GRID',
+							$author$project$Types$DecodingError(err));
+						var updated = _Utils_update(
+							$author$project$Pages$TaskList$emptyTaskListModel,
+							{taskValidationErrors: validationErrors});
+						return _Utils_Tuple2(
+							_Utils_update(
+								model,
+								{
+									route: $author$project$Main$TaskList(updated)
+								}),
+							$elm$core$Platform$Cmd$none);
+					}
+				}
+			case 'GeoJsonInputMouseInteraction':
+				var event = msg.a;
+				var tlm = function () {
+					var _v10 = model.route;
+					if (_v10.$ === 'TaskList') {
+						var taskListModel = _v10.a;
+						return taskListModel;
+					} else {
+						return $author$project$Pages$TaskList$emptyTaskListModel;
+					}
+				}();
+				var cmd = function () {
+					if (event.$ === 'Pick') {
+						return A2(
+							$elm$file$File$Select$files,
+							_List_fromArray(
+								['*.geojson', '*.json']),
+							$author$project$Types$GotFiles);
+					} else {
+						return $elm$core$Platform$Cmd$none;
+					}
+				}();
+				return _Utils_Tuple2(
+					_Utils_update(
+						model,
+						{
+							route: $author$project$Main$TaskList(
+								A2($author$project$Pages$TaskList$setInputState, event, tlm))
+						}),
+					cmd);
+			default:
+				return _Utils_Tuple2(model, $elm$core$Platform$Cmd$none);
 		}
 	});
 var $mdgriffith$elm_ui$Internal$Model$AlignX = function (a) {
@@ -13637,15 +14427,6 @@ var $mdgriffith$elm_ui$Internal$Model$staticRoot = function (opts) {
 				_List_Nil);
 	}
 };
-var $elm$json$Json$Encode$list = F2(
-	function (func, entries) {
-		return _Json_wrap(
-			A3(
-				$elm$core$List$foldl,
-				_Json_addEntry(func),
-				_Json_emptyArray(_Utils_Tuple0),
-				entries));
-	});
 var $mdgriffith$elm_ui$Internal$Model$fontName = function (font) {
 	switch (font.$) {
 		case 'Serif':
@@ -18481,27 +19262,17 @@ var $Orasund$elm_ui_framework$Framework$Button$simple = _Utils_ap(
 					])),
 				A2($mdgriffith$elm_ui$Element$paddingXY, 16, 12)
 			])));
-var $author$project$Styled$styledSecondaryText = F2(
-	function (attrs, s) {
-		return A2(
-			$mdgriffith$elm_ui$Element$el,
-			A2(
-				$elm$core$List$cons,
-				$mdgriffith$elm_ui$Element$Font$color($author$project$Styled$secondary),
-				attrs),
-			$mdgriffith$elm_ui$Element$text(s));
-	});
-var $author$project$Styled$submitButton = F4(
-	function (predicate, value, hint, msg) {
+var $author$project$Styled$submitButton = F3(
+	function (predicate, value, msg) {
 		var allowSubmit = predicate(value);
+		var bgColor = allowSubmit ? $author$project$Styled$accent : $Orasund$elm_ui_framework$Framework$Color$lightGrey;
 		return A2(
 			$mdgriffith$elm_ui$Element$column,
 			_List_fromArray(
 				[
 					$mdgriffith$elm_ui$Element$spacing(5)
 				]),
-			A2(
-				$elm$core$List$cons,
+			$elm$core$List$singleton(
 				A2(
 					$mdgriffith$elm_ui$Element$el,
 					_List_Nil,
@@ -18511,18 +19282,21 @@ var $author$project$Styled$submitButton = F4(
 							$Orasund$elm_ui_framework$Framework$Button$simple,
 							_List_fromArray(
 								[
-									$mdgriffith$elm_ui$Element$Background$color($author$project$Styled$accent),
+									$mdgriffith$elm_ui$Element$Background$color(bgColor),
 									$mdgriffith$elm_ui$Element$centerX,
-									$mdgriffith$elm_ui$Element$Border$color($author$project$Styled$primary)
+									$mdgriffith$elm_ui$Element$Border$color($author$project$Styled$primary),
+									$mdgriffith$elm_ui$Element$htmlAttribute(
+									$elm$html$Html$Attributes$disabled(!allowSubmit)),
+									$mdgriffith$elm_ui$Element$htmlAttribute(
+									A2(
+										$elm$html$Html$Attributes$style,
+										'cursor',
+										allowSubmit ? 'pointer' : 'not-allowed'))
 								])),
 						{
 							label: A2($author$project$Styled$styledPrimaryText, _List_Nil, 'Submit'),
 							onPress: allowSubmit ? $elm$core$Maybe$Just(msg) : $elm$core$Maybe$Nothing
-						})),
-				allowSubmit ? _List_Nil : _List_fromArray(
-					[
-						A2($author$project$Styled$styledSecondaryText, _List_Nil, hint)
-					])));
+						}))));
 	});
 var $author$project$Main$loginPage = function (model) {
 	return A2(
@@ -18564,11 +19338,10 @@ var $author$project$Main$loginPage = function (model) {
 					]),
 				_List_fromArray(
 					[
-						A4(
+						A3(
 						$author$project$Styled$submitButton,
 						A2($elm$core$Basics$composeL, $elm$core$Basics$not, $elm$core$String$isEmpty),
 						A2($elm$core$Maybe$withDefault, '', model.secretsUnsubmitted),
-						'Please enter a token',
 						$author$project$Types$TokenSubmit)
 					]))
 			]));
@@ -18728,10 +19501,18 @@ var $author$project$Pages$TaskList$allowTaskSubmit = F2(
 var $author$project$Types$NameExecution = function (a) {
 	return {$: 'NameExecution', a: a};
 };
+var $author$project$Types$Enter = {$: 'Enter'};
+var $author$project$Types$GeoJsonInputMouseInteraction = function (a) {
+	return {$: 'GeoJsonInputMouseInteraction', a: a};
+};
+var $author$project$Types$Leave = {$: 'Leave'};
+var $author$project$Types$Over = {$: 'Over'};
+var $author$project$Types$Pick = {$: 'Pick'};
 var $author$project$Types$ValidateWith = function (a) {
 	return {$: 'ValidateWith', a: a};
 };
 var $elm$core$String$fromList = _String_fromList;
+var $mdgriffith$elm_ui$Element$html = $mdgriffith$elm_ui$Internal$Model$unstyled;
 var $author$project$Pages$TaskList$fontRed = $mdgriffith$elm_ui$Element$Font$color(
 	A3($mdgriffith$elm_ui$Element$rgb255, 255, 0, 0));
 var $author$project$Pages$TaskList$getErrField = function (err) {
@@ -18793,6 +19574,23 @@ var $author$project$Pages$TaskList$makeErr = function (err) {
 				]);
 	}
 };
+var $author$project$Pages$TaskList$makeHelpfulErrorMessage = function (err) {
+	if (err.$ === 'SchemaError') {
+		var errs = err.a;
+		return A2($elm$core$List$concatMap, $author$project$Pages$TaskList$makeErr, errs);
+	} else {
+		return _List_fromArray(
+			[
+				A2(
+				$mdgriffith$elm_ui$Element$row,
+				_List_Nil,
+				_List_fromArray(
+					[
+						$mdgriffith$elm_ui$Element$text('Structure of JSON in this field was unexpected')
+					]))
+			]);
+	}
+};
 var $elm$core$String$foldr = _String_foldr;
 var $elm$core$String$toList = function (string) {
 	return A3($elm$core$String$foldr, $elm$core$List$cons, _List_Nil, string);
@@ -18849,7 +19647,6 @@ var $elm$json$Json$Encode$dict = F3(
 				_Json_emptyObject(_Utils_Tuple0),
 				dictionary));
 	});
-var $elm$json$Json$Encode$float = _Json_wrap;
 var $elm$core$Array$fromListHelp = F3(
 	function (list, nodeList, nodeListSize) {
 		fromListHelp:
@@ -18886,7 +19683,6 @@ var $elm$core$Array$fromList = function (list) {
 	}
 };
 var $elm$json$Json$Encode$int = _Json_wrap;
-var $elm$json$Json$Encode$null = _Json_encodeNull;
 var $author$project$Pages$TaskList$toResult = F2(
 	function (s, m) {
 		if (m.$ === 'Just') {
@@ -19009,64 +19805,203 @@ var $author$project$Pages$TaskList$toValue = F2(
 	function (schema, s) {
 		return A2($author$project$Pages$TaskList$encodeValue, schema.type_, s);
 	});
-var $author$project$Pages$TaskList$schemaToForm = F3(
-	function (formValues, errors, schema) {
-		var toInput = function (_v5) {
-			var k = _v5.a;
-			var v = _v5.b;
-			return ($elm$core$String$toLower(k) !== 'task_grid') ? A5(
-				$author$project$Styled$textInput,
+var $elm$html$Html$button = _VirtualDom_node('button');
+var $elm$file$File$decoder = _File_decoder;
+var $elm$json$Json$Decode$oneOrMoreHelp = F2(
+	function (toValue, xs) {
+		if (!xs.b) {
+			return $elm$json$Json$Decode$fail('a ARRAY with at least ONE element');
+		} else {
+			var y = xs.a;
+			var ys = xs.b;
+			return $elm$json$Json$Decode$succeed(
+				A2(toValue, y, ys));
+		}
+	});
+var $elm$json$Json$Decode$oneOrMore = F2(
+	function (toValue, decoder) {
+		return A2(
+			$elm$json$Json$Decode$andThen,
+			$elm$json$Json$Decode$oneOrMoreHelp(toValue),
+			$elm$json$Json$Decode$list(decoder));
+	});
+var $author$project$FileInput$dropDecoder = function (f) {
+	return A2(
+		$elm$json$Json$Decode$at,
+		_List_fromArray(
+			['dataTransfer', 'files']),
+		A2($elm$json$Json$Decode$oneOrMore, f, $elm$file$File$decoder));
+};
+var $author$project$FileInput$hijack = function (msg) {
+	return _Utils_Tuple2(msg, true);
+};
+var $author$project$FileInput$hijackOn = F2(
+	function (event, decoder) {
+		return A2(
+			$elm$html$Html$Events$preventDefaultOn,
+			event,
+			A2($elm$json$Json$Decode$map, $author$project$FileInput$hijack, decoder));
+	});
+var $author$project$FileInput$view = function (handler) {
+	return A2(
+		$elm$html$Html$div,
+		_List_fromArray(
+			[
+				A2($elm$html$Html$Attributes$style, 'border-radius', '20px'),
+				A2($elm$html$Html$Attributes$style, 'padding', '5px'),
+				A2($elm$html$Html$Attributes$style, 'display', 'flex'),
+				A2($elm$html$Html$Attributes$style, 'flex-direction', 'column'),
+				A2($elm$html$Html$Attributes$style, 'justify-content', 'center'),
+				A2($elm$html$Html$Attributes$style, 'align-items', 'center'),
+				A2(
+				$author$project$FileInput$hijackOn,
+				'dragenter',
+				$elm$json$Json$Decode$succeed(handler.onEnter)),
+				A2(
+				$author$project$FileInput$hijackOn,
+				'dragover',
+				$elm$json$Json$Decode$succeed(handler.onOver)),
+				A2(
+				$author$project$FileInput$hijackOn,
+				'dragleave',
+				$elm$json$Json$Decode$succeed(handler.onLeave)),
+				A2(
+				$author$project$FileInput$hijackOn,
+				'drop',
+				$author$project$FileInput$dropDecoder(handler.onDrop))
+			]),
+		_List_fromArray(
+			[
+				A2(
+				$elm$html$Html$button,
 				_List_fromArray(
 					[
-						$mdgriffith$elm_ui$Element$width(
-						A2($mdgriffith$elm_ui$Element$minimum, 300, $mdgriffith$elm_ui$Element$fill))
+						$elm$html$Html$Events$onClick(handler.onPick)
 					]),
-				function (s) {
-					return $author$project$Types$ValidateWith(
-						{
-							fieldName: k,
-							fieldValue: A2($author$project$Pages$TaskList$toValue, v, s),
-							schema: v
-						});
-				},
-				function () {
-					var _v4 = A2($elm$core$Dict$get, k, formValues);
-					if (_v4.$ === 'Just') {
-						if (_v4.a.$ === 'Ok') {
-							var jsonValue = _v4.a.a;
-							return $elm$core$Maybe$Just(
-								$elm$core$String$fromList(
-									A2(
-										$elm$core$List$filter,
-										$elm$core$Basics$neq(
-											_Utils_chr('\"')),
-										$elm$core$String$toList(
-											A2($elm$json$Json$Encode$encode, 0, jsonValue)))));
+				_List_fromArray(
+					[
+						$elm$html$Html$text('Select or drag and drop a task grid geojson')
+					]))
+			]));
+};
+var $author$project$Pages$TaskList$schemaToForm = F4(
+	function (inputEvent, formValues, errors, schema) {
+		var toInput = function (_v11) {
+			var k = _v11.a;
+			var v = _v11.b;
+			if ($elm$core$String$toLower(k) !== 'task_grid') {
+				return A5(
+					$author$project$Styled$textInput,
+					_List_fromArray(
+						[
+							$mdgriffith$elm_ui$Element$width(
+							A2($mdgriffith$elm_ui$Element$minimum, 300, $mdgriffith$elm_ui$Element$fill))
+						]),
+					function (s) {
+						return $author$project$Types$ValidateWith(
+							{
+								fieldName: k,
+								fieldValue: A2($author$project$Pages$TaskList$toValue, v, s),
+								schema: v
+							});
+					},
+					function () {
+						var _v4 = A2($elm$core$Dict$get, k, formValues);
+						if (_v4.$ === 'Just') {
+							if (_v4.a.$ === 'Ok') {
+								var jsonValue = _v4.a.a;
+								return $elm$core$Maybe$Just(
+									$elm$core$String$fromList(
+										A2(
+											$elm$core$List$filter,
+											$elm$core$Basics$neq(
+												_Utils_chr('\"')),
+											$elm$core$String$toList(
+												A2($elm$json$Json$Encode$encode, 0, jsonValue)))));
+							} else {
+								var s = _v4.a.a;
+								return $elm$core$Maybe$Just(s);
+							}
 						} else {
-							var s = _v4.a.a;
-							return $elm$core$Maybe$Just(s);
+							return $elm$core$Maybe$Nothing;
+						}
+					}(),
+					k + (': ' + $author$project$Pages$TaskList$showType(v.type_)),
+					k);
+			} else {
+				var extraStyle = function () {
+					if (inputEvent.$ === 'Just') {
+						switch (inputEvent.a.$) {
+							case 'Over':
+								var _v7 = inputEvent.a;
+								return _List_fromArray(
+									[$author$project$Styled$secondaryShadow]);
+							case 'Enter':
+								var _v8 = inputEvent.a;
+								return _List_Nil;
+							case 'Leave':
+								var _v9 = inputEvent.a;
+								return _List_Nil;
+							default:
+								var _v10 = inputEvent.a;
+								return _List_Nil;
 						}
 					} else {
-						return $elm$core$Maybe$Nothing;
+						return _List_Nil;
 					}
-				}(),
-				k + (': ' + $author$project$Pages$TaskList$showType(v.type_)),
-				k) : A2(
-				$mdgriffith$elm_ui$Element$row,
-				_List_Nil,
-				_List_fromArray(
-					[
-						$mdgriffith$elm_ui$Element$text('file input goes here')
-					]));
+				}();
+				return A2(
+					$elm$core$Maybe$withDefault,
+					A2(
+						$mdgriffith$elm_ui$Element$row,
+						A2(
+							$elm$core$List$cons,
+							$mdgriffith$elm_ui$Element$width(
+								A2($mdgriffith$elm_ui$Element$minimum, 300, $mdgriffith$elm_ui$Element$fill)),
+							extraStyle),
+						_List_fromArray(
+							[
+								$mdgriffith$elm_ui$Element$html(
+								$author$project$FileInput$view(
+									{
+										onDrop: $author$project$Types$GotFiles,
+										onEnter: $author$project$Types$GeoJsonInputMouseInteraction($author$project$Types$Enter),
+										onLeave: $author$project$Types$GeoJsonInputMouseInteraction($author$project$Types$Leave),
+										onOver: $author$project$Types$GeoJsonInputMouseInteraction($author$project$Types$Over),
+										onPick: $author$project$Types$GeoJsonInputMouseInteraction($author$project$Types$Pick)
+									}))
+							])),
+					A2(
+						$elm$core$Maybe$andThen,
+						function (result) {
+							if (result.$ === 'Ok') {
+								var data = result.a;
+								return A2(
+									$elm$core$Basics$always,
+									$elm$core$Maybe$Just(
+										A2(
+											$mdgriffith$elm_ui$Element$row,
+											_List_Nil,
+											_List_fromArray(
+												[
+													$mdgriffith$elm_ui$Element$text('Successful geojson upload!')
+												]))),
+									data);
+							} else {
+								return $elm$core$Maybe$Nothing;
+							}
+						},
+						A2($elm$core$Dict$get, 'TASK_GRID', formValues)));
+			}
 		};
 		var errs = function (_v3) {
 			var k = _v3.a;
 			return A2(
-				$elm$core$List$concatMap,
-				$author$project$Pages$TaskList$makeErr,
+				$elm$core$Maybe$withDefault,
+				_List_Nil,
 				A2(
-					$elm$core$Maybe$withDefault,
-					_List_Nil,
+					$elm$core$Maybe$map,
+					$author$project$Pages$TaskList$makeHelpfulErrorMessage,
 					A2($elm$core$Dict$get, k, errors)));
 		};
 		var inputRow = function (_v2) {
@@ -19119,8 +20054,8 @@ var $author$project$Pages$TaskList$schemaToForm = F3(
 			_List_Nil,
 			A2($elm$core$Maybe$map, makeInput, schema.properties));
 	});
-var $author$project$Pages$TaskList$executionInput = F3(
-	function (formValues, errors, task) {
+var $author$project$Pages$TaskList$executionInput = F4(
+	function (inputEvent, formValues, errors, task) {
 		var _v0 = task.validator;
 		if (_v0.$ === 'BooleanSchema') {
 			return _List_fromArray(
@@ -19145,12 +20080,22 @@ var $author$project$Pages$TaskList$executionInput = F3(
 					formValues.executionName,
 					'Execution name',
 					'New execution name'),
-				A3($author$project$Pages$TaskList$schemaToForm, formValues.fromSchema, errors, subSchema));
+				A4($author$project$Pages$TaskList$schemaToForm, inputEvent, formValues.fromSchema, errors, subSchema));
 		}
 	});
 var $author$project$Types$TaskSelect = function (a) {
 	return {$: 'TaskSelect', a: a};
 };
+var $author$project$Styled$styledSecondaryText = F2(
+	function (attrs, s) {
+		return A2(
+			$mdgriffith$elm_ui$Element$el,
+			A2(
+				$elm$core$List$cons,
+				$mdgriffith$elm_ui$Element$Font$color($author$project$Styled$secondary),
+				attrs),
+			$mdgriffith$elm_ui$Element$text(s));
+	});
 var $author$project$Pages$TaskList$tasksLink = F2(
 	function (selectedId, task) {
 		return _Utils_eq(
@@ -19294,7 +20239,7 @@ var $author$project$Pages$TaskList$taskList = function (model) {
 						$elm$core$Maybe$map,
 						function (selected) {
 							return _Utils_ap(
-								A3($author$project$Pages$TaskList$executionInput, model.formValues, model.taskValidationErrors, selected),
+								A4($author$project$Pages$TaskList$executionInput, model.inputState, model.formValues, model.taskValidationErrors, selected),
 								_List_fromArray(
 									[
 										A2(
@@ -19302,11 +20247,10 @@ var $author$project$Pages$TaskList$taskList = function (model) {
 										_List_Nil,
 										_List_fromArray(
 											[
-												A4(
+												A3(
 												$author$project$Styled$submitButton,
 												$author$project$Pages$TaskList$allowTaskSubmit(model.activeSchema),
 												model.formValues,
-												'Some inputs are invalid',
 												$author$project$Types$CreateExecution(
 													A3($author$project$Pages$TaskList$toExecutionCreate, selected.name, selected.id, model.formValues)))
 											]))
@@ -19316,56 +20260,42 @@ var $author$project$Pages$TaskList$taskList = function (model) {
 			]));
 };
 var $author$project$Main$view = function (model) {
-	var _v0 = _Utils_Tuple3(
-		model.route,
-		model.secrets,
-		_Utils_Tuple2(model.taskListModel, model.executionListModel));
+	var _v0 = _Utils_Tuple2(model.route, model.secrets);
 	_v0$2:
 	while (true) {
 		if (_v0.b.$ === 'Just') {
 			switch (_v0.a.$) {
 				case 'TaskList':
-					if (_v0.c.a.$ === 'Just') {
-						var _v1 = _v0.a;
-						var _v2 = _v0.c;
-						var tlm = _v2.a.a;
-						var taskListBody = $author$project$Pages$TaskList$taskList(tlm);
-						return {
-							body: _List_fromArray(
-								[
-									A2(
-									$mdgriffith$elm_ui$Element$layout,
-									_List_Nil,
-									$author$project$Main$logoTop(
-										_List_fromArray(
-											[taskListBody])))
-								]),
-							title: 'Available Tasks'
-						};
-					} else {
-						break _v0$2;
-					}
+					var tlm = _v0.a.a;
+					var taskListBody = $author$project$Pages$TaskList$taskList(tlm);
+					return {
+						body: _List_fromArray(
+							[
+								A2(
+								$mdgriffith$elm_ui$Element$layout,
+								_List_Nil,
+								$author$project$Main$logoTop(
+									_List_fromArray(
+										[taskListBody])))
+							]),
+						title: 'Available Tasks'
+					};
 				case 'ExecutionList':
-					if (_v0.c.b.$ === 'Just') {
-						var _v3 = _v0.c;
-						var elm = _v3.b.a;
-						return {
-							body: _List_fromArray(
-								[
-									A2(
-									$mdgriffith$elm_ui$Element$layout,
-									_List_Nil,
-									$author$project$Main$logoTop(
-										_List_fromArray(
-											[
-												$author$project$Pages$ExecutionList$executionList(elm)
-											])))
-								]),
-							title: 'Execution list'
-						};
-					} else {
-						break _v0$2;
-					}
+					var elm = _v0.a.a;
+					return {
+						body: _List_fromArray(
+							[
+								A2(
+								$mdgriffith$elm_ui$Element$layout,
+								_List_Nil,
+								$author$project$Main$logoTop(
+									_List_fromArray(
+										[
+											$author$project$Pages$ExecutionList$executionList(elm)
+										])))
+							]),
+						title: 'Execution list'
+					};
 				default:
 					break _v0$2;
 			}

--- a/api/src/main/resources/assets/index.html
+++ b/api/src/main/resources/assets/index.html
@@ -5863,15 +5863,17 @@ var $author$project$Main$init = F3(
 	});
 var $elm$core$Platform$Sub$batch = _Platform_batch;
 var $elm$core$Platform$Sub$none = $elm$core$Platform$Sub$batch(_List_Nil);
-var $author$project$Types$DecodingError = function (a) {
-	return {$: 'DecodingError', a: a};
-};
+var $author$project$Types$DecodingError = F3(
+	function (a, b, c) {
+		return {$: 'DecodingError', a: a, b: b, c: c};
+	});
 var $author$project$Main$ExecutionList = function (a) {
 	return {$: 'ExecutionList', a: a};
 };
-var $author$project$Types$GeoJsonData = function (a) {
-	return {$: 'GeoJsonData', a: a};
-};
+var $author$project$Types$GeoJsonData = F3(
+	function (a, b, c) {
+		return {$: 'GeoJsonData', a: a, b: b, c: c};
+	});
 var $author$project$Types$GotFiles = F2(
 	function (a, b) {
 		return {$: 'GotFiles', a: a, b: b};
@@ -6137,7 +6139,7 @@ var $elm$core$Set$Set_elm_builtin = function (a) {
 var $elm$core$Set$empty = $elm$core$Set$Set_elm_builtin($elm$core$Dict$empty);
 var $author$project$Pages$ExecutionList$emptyExecutionListModel = {executionNameSearch: $elm$core$Maybe$Nothing, executions: _List_Nil, forTask: $elm$core$Maybe$Nothing, selectedExecutions: $elm$core$Set$empty};
 var $author$project$Pages$TaskList$emptyFormValues = {executionName: $elm$core$Maybe$Nothing, fromSchema: $elm$core$Dict$empty};
-var $author$project$Pages$TaskList$emptyTaskListModel = {activeSchema: $elm$core$Maybe$Nothing, formValues: $author$project$Pages$TaskList$emptyFormValues, inputState: $elm$core$Maybe$Nothing, selectedTask: $elm$core$Maybe$Nothing, taskValidationErrors: $elm$core$Dict$empty, tasks: _List_Nil};
+var $author$project$Pages$TaskList$emptyTaskListModel = {activeSchema: $elm$core$Maybe$Nothing, fileName: $elm$core$Maybe$Nothing, fileSize: $elm$core$Maybe$Nothing, formValues: $author$project$Pages$TaskList$emptyFormValues, inputState: $elm$core$Maybe$Nothing, selectedTask: $elm$core$Maybe$Nothing, taskValidationErrors: $elm$core$Dict$empty, tasks: _List_Nil};
 var $elm$json$Json$Encode$float = _Json_wrap;
 var $elm$json$Json$Encode$list = F2(
 	function (func, entries) {
@@ -9026,6 +9028,7 @@ var $elm$core$Set$member = F2(
 		var dict = _v0.a;
 		return A2($elm$core$Dict$member, key, dict);
 	});
+var $elm$file$File$name = _File_name;
 var $elm$url$Url$Parser$State = F5(
 	function (visited, unvisited, params, frag, value) {
 		return {frag: frag, params: params, unvisited: unvisited, value: value, visited: visited};
@@ -9391,6 +9394,7 @@ var $elm$core$Dict$singleton = F2(
 	function (key, value) {
 		return A5($elm$core$Dict$RBNode_elm_builtin, $elm$core$Dict$Black, key, value, $elm$core$Dict$RBEmpty_elm_builtin, $elm$core$Dict$RBEmpty_elm_builtin);
 	});
+var $elm$file$File$size = _File_size;
 var $elm$file$File$toString = _File_toString;
 var $elm$core$Dict$foldl = F3(
 	function (func, acc, dict) {
@@ -11845,14 +11849,37 @@ var $author$project$Main$update = F2(
 					$elm$core$Platform$Cmd$none);
 			case 'GotFiles':
 				var head = msg.a;
+				var fileSize = $elm$file$File$size(head);
+				var fileName = $elm$file$File$name(head);
+				var updatedTlm = A2(
+					$elm$core$Maybe$withDefault,
+					$author$project$Main$Login,
+					A2(
+						$elm$core$Maybe$map,
+						$author$project$Main$TaskList,
+						A2(
+							$author$project$Main$updateTaskListModel,
+							function (tlm) {
+								return _Utils_update(
+									tlm,
+									{
+										fileName: $elm$core$Maybe$Just(fileName),
+										fileSize: $elm$core$Maybe$Just(fileSize)
+									});
+							},
+							model.route)));
 				return _Utils_Tuple2(
-					model,
+					_Utils_update(
+						model,
+						{route: updatedTlm}),
 					A2(
 						$elm$core$Task$perform,
-						$author$project$Types$GeoJsonData,
+						A2($author$project$Types$GeoJsonData, fileName, fileSize),
 						$elm$file$File$toString(head)));
 			case 'GeoJsonData':
-				var data = msg.a;
+				var fileName = msg.a;
+				var fileSize = msg.b;
+				var data = msg.c;
 				var _v8 = _Utils_Tuple2(
 					A2($elm$json$Json$Decode$decodeString, $mgold$elm_geojson$GeoJson$decoder, data),
 					model.route);
@@ -11912,7 +11939,7 @@ var $author$project$Main$update = F2(
 						var addition = A2(
 							$elm$core$Dict$singleton,
 							'TASK_GRID',
-							$author$project$Types$DecodingError(err));
+							A3($author$project$Types$DecodingError, fileName, fileSize, err));
 						var updated = _Utils_update(
 							tlm,
 							{
@@ -11930,7 +11957,7 @@ var $author$project$Main$update = F2(
 						var validationErrors = A2(
 							$elm$core$Dict$singleton,
 							'TASK_GRID',
-							$author$project$Types$DecodingError(err));
+							A3($author$project$Types$DecodingError, fileName, fileSize, err));
 						var updated = _Utils_update(
 							$author$project$Pages$TaskList$emptyTaskListModel,
 							{taskValidationErrors: validationErrors});
@@ -19564,11 +19591,258 @@ var $author$project$Pages$TaskList$makeErr = function (err) {
 				]);
 	}
 };
+var $elm$core$Basics$abs = function (n) {
+	return (n < 0) ? (-n) : n;
+};
+var $elm$core$String$foldr = _String_foldr;
+var $elm$core$String$toList = function (string) {
+	return A3($elm$core$String$foldr, $elm$core$List$cons, _List_Nil, string);
+};
+var $myrho$elm_round$Round$addSign = F2(
+	function (signed, str) {
+		var isNotZero = A2(
+			$elm$core$List$any,
+			function (c) {
+				return (!_Utils_eq(
+					c,
+					_Utils_chr('0'))) && (!_Utils_eq(
+					c,
+					_Utils_chr('.')));
+			},
+			$elm$core$String$toList(str));
+		return _Utils_ap(
+			(signed && isNotZero) ? '-' : '',
+			str);
+	});
+var $elm$core$String$cons = _String_cons;
+var $elm$core$Char$fromCode = _Char_fromCode;
+var $myrho$elm_round$Round$increaseNum = function (_v0) {
+	var head = _v0.a;
+	var tail = _v0.b;
+	if (_Utils_eq(
+		head,
+		_Utils_chr('9'))) {
+		var _v1 = $elm$core$String$uncons(tail);
+		if (_v1.$ === 'Nothing') {
+			return '01';
+		} else {
+			var headtail = _v1.a;
+			return A2(
+				$elm$core$String$cons,
+				_Utils_chr('0'),
+				$myrho$elm_round$Round$increaseNum(headtail));
+		}
+	} else {
+		var c = $elm$core$Char$toCode(head);
+		return ((c >= 48) && (c < 57)) ? A2(
+			$elm$core$String$cons,
+			$elm$core$Char$fromCode(c + 1),
+			tail) : '0';
+	}
+};
+var $elm$core$Basics$isInfinite = _Basics_isInfinite;
+var $elm$core$Basics$isNaN = _Basics_isNaN;
+var $elm$core$String$fromChar = function (_char) {
+	return A2($elm$core$String$cons, _char, '');
+};
+var $elm$core$Bitwise$shiftRightBy = _Bitwise_shiftRightBy;
+var $elm$core$String$repeatHelp = F3(
+	function (n, chunk, result) {
+		return (n <= 0) ? result : A3(
+			$elm$core$String$repeatHelp,
+			n >> 1,
+			_Utils_ap(chunk, chunk),
+			(!(n & 1)) ? result : _Utils_ap(result, chunk));
+	});
+var $elm$core$String$repeat = F2(
+	function (n, chunk) {
+		return A3($elm$core$String$repeatHelp, n, chunk, '');
+	});
+var $elm$core$String$padRight = F3(
+	function (n, _char, string) {
+		return _Utils_ap(
+			string,
+			A2(
+				$elm$core$String$repeat,
+				n - $elm$core$String$length(string),
+				$elm$core$String$fromChar(_char)));
+	});
+var $elm$core$String$reverse = _String_reverse;
+var $myrho$elm_round$Round$splitComma = function (str) {
+	var _v0 = A2($elm$core$String$split, '.', str);
+	if (_v0.b) {
+		if (_v0.b.b) {
+			var before = _v0.a;
+			var _v1 = _v0.b;
+			var after = _v1.a;
+			return _Utils_Tuple2(before, after);
+		} else {
+			var before = _v0.a;
+			return _Utils_Tuple2(before, '0');
+		}
+	} else {
+		return _Utils_Tuple2('0', '0');
+	}
+};
+var $myrho$elm_round$Round$toDecimal = function (fl) {
+	var _v0 = A2(
+		$elm$core$String$split,
+		'e',
+		$elm$core$String$fromFloat(
+			$elm$core$Basics$abs(fl)));
+	if (_v0.b) {
+		if (_v0.b.b) {
+			var num = _v0.a;
+			var _v1 = _v0.b;
+			var exp = _v1.a;
+			var e = A2(
+				$elm$core$Maybe$withDefault,
+				0,
+				$elm$core$String$toInt(
+					A2($elm$core$String$startsWith, '+', exp) ? A2($elm$core$String$dropLeft, 1, exp) : exp));
+			var _v2 = $myrho$elm_round$Round$splitComma(num);
+			var before = _v2.a;
+			var after = _v2.b;
+			var total = _Utils_ap(before, after);
+			var zeroed = (e < 0) ? A2(
+				$elm$core$Maybe$withDefault,
+				'0',
+				A2(
+					$elm$core$Maybe$map,
+					function (_v3) {
+						var a = _v3.a;
+						var b = _v3.b;
+						return a + ('.' + b);
+					},
+					A2(
+						$elm$core$Maybe$map,
+						$elm$core$Tuple$mapFirst($elm$core$String$fromChar),
+						$elm$core$String$uncons(
+							_Utils_ap(
+								A2(
+									$elm$core$String$repeat,
+									$elm$core$Basics$abs(e),
+									'0'),
+								total))))) : A3(
+				$elm$core$String$padRight,
+				e + 1,
+				_Utils_chr('0'),
+				total);
+			return _Utils_ap(
+				(fl < 0) ? '-' : '',
+				zeroed);
+		} else {
+			var num = _v0.a;
+			return _Utils_ap(
+				(fl < 0) ? '-' : '',
+				num);
+		}
+	} else {
+		return '';
+	}
+};
+var $myrho$elm_round$Round$roundFun = F3(
+	function (functor, s, fl) {
+		if ($elm$core$Basics$isInfinite(fl) || $elm$core$Basics$isNaN(fl)) {
+			return $elm$core$String$fromFloat(fl);
+		} else {
+			var signed = fl < 0;
+			var _v0 = $myrho$elm_round$Round$splitComma(
+				$myrho$elm_round$Round$toDecimal(
+					$elm$core$Basics$abs(fl)));
+			var before = _v0.a;
+			var after = _v0.b;
+			var r = $elm$core$String$length(before) + s;
+			var normalized = _Utils_ap(
+				A2($elm$core$String$repeat, (-r) + 1, '0'),
+				A3(
+					$elm$core$String$padRight,
+					r,
+					_Utils_chr('0'),
+					_Utils_ap(before, after)));
+			var totalLen = $elm$core$String$length(normalized);
+			var roundDigitIndex = A2($elm$core$Basics$max, 1, r);
+			var increase = A2(
+				functor,
+				signed,
+				A3($elm$core$String$slice, roundDigitIndex, totalLen, normalized));
+			var remains = A3($elm$core$String$slice, 0, roundDigitIndex, normalized);
+			var num = increase ? $elm$core$String$reverse(
+				A2(
+					$elm$core$Maybe$withDefault,
+					'1',
+					A2(
+						$elm$core$Maybe$map,
+						$myrho$elm_round$Round$increaseNum,
+						$elm$core$String$uncons(
+							$elm$core$String$reverse(remains))))) : remains;
+			var numLen = $elm$core$String$length(num);
+			var numZeroed = (num === '0') ? num : ((s <= 0) ? _Utils_ap(
+				num,
+				A2(
+					$elm$core$String$repeat,
+					$elm$core$Basics$abs(s),
+					'0')) : ((_Utils_cmp(
+				s,
+				$elm$core$String$length(after)) < 0) ? (A3($elm$core$String$slice, 0, numLen - s, num) + ('.' + A3($elm$core$String$slice, numLen - s, numLen, num))) : _Utils_ap(
+				before + '.',
+				A3(
+					$elm$core$String$padRight,
+					s,
+					_Utils_chr('0'),
+					after))));
+			return A2($myrho$elm_round$Round$addSign, signed, numZeroed);
+		}
+	});
+var $myrho$elm_round$Round$round = $myrho$elm_round$Round$roundFun(
+	F2(
+		function (signed, str) {
+			var _v0 = $elm$core$String$uncons(str);
+			if (_v0.$ === 'Nothing') {
+				return false;
+			} else {
+				if ('5' === _v0.a.a.valueOf()) {
+					if (_v0.a.b === '') {
+						var _v1 = _v0.a;
+						return !signed;
+					} else {
+						var _v2 = _v0.a;
+						return true;
+					}
+				} else {
+					var _v3 = _v0.a;
+					var _int = _v3.a;
+					return function (i) {
+						return ((i > 53) && signed) || ((i >= 53) && (!signed));
+					}(
+						$elm$core$Char$toCode(_int));
+				}
+			}
+		}));
+var $author$project$Pages$TaskList$showFileSize = function (bytes) {
+	var mb = (bytes / (1024 * 1024)) | 0;
+	var bytesAfterMb = A2($elm$core$Basics$modBy, 1024 * 1024, bytes);
+	var kb = (bytesAfterMb / 1024) | 0;
+	var fractionalMb = kb / 1024;
+	return (mb > 0) ? (A2($myrho$elm_round$Round$round, 3, mb + fractionalMb) + ' mb') : ((kb > 0) ? ($elm$core$String$fromInt(kb) + ' kb') : ($elm$core$String$fromInt(bytes) + ' bytes'));
+};
+var $author$project$Styled$styledSecondaryText = F2(
+	function (attrs, s) {
+		return A2(
+			$mdgriffith$elm_ui$Element$el,
+			A2(
+				$elm$core$List$cons,
+				$mdgriffith$elm_ui$Element$Font$color($author$project$Styled$secondary),
+				attrs),
+			$mdgriffith$elm_ui$Element$text(s));
+	});
 var $author$project$Pages$TaskList$makeHelpfulErrorMessage = function (err) {
 	if (err.$ === 'SchemaError') {
 		var errs = err.a;
 		return A2($elm$core$List$concatMap, $author$project$Pages$TaskList$makeErr, errs);
 	} else {
+		var fileName = err.a;
+		var fileSize = err.b;
 		return _List_fromArray(
 			[
 				A2(
@@ -19580,15 +19854,29 @@ var $author$project$Pages$TaskList$makeHelpfulErrorMessage = function (err) {
 					]),
 				_List_fromArray(
 					[
-						$mdgriffith$elm_ui$Element$text('Unexpected JSON structure')
+						A2(
+						$author$project$Styled$styledSecondaryText,
+						_List_Nil,
+						fileName + (' does not appear to be geojson. Size: ' + ($author$project$Pages$TaskList$showFileSize(fileSize) + '.')))
 					]))
 			]);
 	}
 };
-var $elm$core$String$foldr = _String_foldr;
-var $elm$core$String$toList = function (string) {
-	return A3($elm$core$String$foldr, $elm$core$List$cons, _List_Nil, string);
-};
+var $elm$core$Maybe$map2 = F3(
+	function (func, ma, mb) {
+		if (ma.$ === 'Nothing') {
+			return $elm$core$Maybe$Nothing;
+		} else {
+			var a = ma.a;
+			if (mb.$ === 'Nothing') {
+				return $elm$core$Maybe$Nothing;
+			} else {
+				var b = mb.a;
+				return $elm$core$Maybe$Just(
+					A2(func, a, b));
+			}
+		}
+	});
 var $elm$core$Elm$JsArray$foldl = _JsArray_foldl;
 var $elm$core$Array$foldl = F3(
 	function (func, baseCase, _v0) {
@@ -19878,8 +20166,8 @@ var $author$project$FileInput$view = function (handler) {
 					]))
 			]));
 };
-var $author$project$Pages$TaskList$schemaToForm = F4(
-	function (inputEvent, formValues, errors, schema) {
+var $author$project$Pages$TaskList$schemaToForm = F6(
+	function (fileSize, fileName, inputEvent, formValues, errors, schema) {
 		var toInput = function (_v11) {
 			var k = _v11.a;
 			var v = _v11.b;
@@ -19978,7 +20266,20 @@ var $author$project$Pages$TaskList$schemaToForm = F4(
 											_List_Nil,
 											_List_fromArray(
 												[
-													A2($author$project$Styled$styledPrimaryText, _List_Nil, 'Successful geojson upload!')
+													A2(
+													$author$project$Styled$styledPrimaryText,
+													_List_Nil,
+													A2(
+														$elm$core$Maybe$withDefault,
+														'Successful geojson upload!',
+														A3(
+															$elm$core$Maybe$map2,
+															F2(
+																function (size, name) {
+																	return 'File: ' + (name + ('. Size: ' + $author$project$Pages$TaskList$showFileSize(size)));
+																}),
+															fileSize,
+															fileName)))
 												]))),
 									data);
 							} else {
@@ -20039,8 +20340,8 @@ var $author$project$Pages$TaskList$schemaToForm = F4(
 			_List_Nil,
 			A2($elm$core$Maybe$map, makeInput, schema.properties));
 	});
-var $author$project$Pages$TaskList$executionInput = F4(
-	function (inputEvent, formValues, errors, task) {
+var $author$project$Pages$TaskList$executionInput = F6(
+	function (fileSize, fileName, inputEvent, formValues, errors, task) {
 		var _v0 = task.validator;
 		if (_v0.$ === 'BooleanSchema') {
 			return _List_fromArray(
@@ -20065,7 +20366,7 @@ var $author$project$Pages$TaskList$executionInput = F4(
 					formValues.executionName,
 					'Execution name',
 					'New execution name'),
-				A4($author$project$Pages$TaskList$schemaToForm, inputEvent, formValues.fromSchema, errors, subSchema));
+				A6($author$project$Pages$TaskList$schemaToForm, fileSize, fileName, inputEvent, formValues.fromSchema, errors, subSchema));
 		}
 	});
 var $mdgriffith$elm_ui$Element$Font$size = function (i) {
@@ -20109,16 +20410,6 @@ var $mdgriffith$elm_ui$Element$link = F2(
 			$mdgriffith$elm_ui$Internal$Model$Unkeyed(
 				_List_fromArray(
 					[label])));
-	});
-var $author$project$Styled$styledSecondaryText = F2(
-	function (attrs, s) {
-		return A2(
-			$mdgriffith$elm_ui$Element$el,
-			A2(
-				$elm$core$List$cons,
-				$mdgriffith$elm_ui$Element$Font$color($author$project$Styled$secondary),
-				attrs),
-			$mdgriffith$elm_ui$Element$text(s));
 	});
 var $author$project$Pages$TaskList$tasksLink = function (task) {
 	return A2(
@@ -20271,7 +20562,7 @@ var $author$project$Pages$TaskList$taskList = function (model) {
 												$mdgriffith$elm_ui$Element$padding(10)
 											]),
 										_Utils_ap(
-											A4($author$project$Pages$TaskList$executionInput, model.inputState, model.formValues, model.taskValidationErrors, selected),
+											A6($author$project$Pages$TaskList$executionInput, model.fileSize, model.fileName, model.inputState, model.formValues, model.taskValidationErrors, selected),
 											_List_fromArray(
 												[
 													A2(

--- a/api/src/main/resources/assets/index.html
+++ b/api/src/main/resources/assets/index.html
@@ -4829,10 +4829,10 @@ var _Bitwise_shiftRightZfBy = F2(function(offset, a)
 {
 	return a >>> offset;
 });
-var $author$project$Main$Navigation = function (a) {
+var $author$project$Types$Navigation = function (a) {
 	return {$: 'Navigation', a: a};
 };
-var $author$project$Main$UrlChanged = function (a) {
+var $author$project$Types$UrlChanged = function (a) {
 	return {$: 'UrlChanged', a: a};
 };
 var $elm$core$Basics$always = F2(
@@ -5629,13 +5629,6 @@ var $elm$core$Task$perform = F2(
 	});
 var $elm$browser$Browser$application = _Browser_application;
 var $author$project$Main$Login = {$: 'Login'};
-var $elm$core$Dict$RBEmpty_elm_builtin = {$: 'RBEmpty_elm_builtin'};
-var $elm$core$Dict$empty = $elm$core$Dict$RBEmpty_elm_builtin;
-var $elm$core$Set$Set_elm_builtin = function (a) {
-	return {$: 'Set_elm_builtin', a: a};
-};
-var $elm$core$Set$empty = $elm$core$Set$Set_elm_builtin($elm$core$Dict$empty);
-var $author$project$Main$emptyFormValues = {executionName: $elm$core$Maybe$Nothing, fromSchema: $elm$core$Dict$empty};
 var $elm$browser$Browser$Navigation$pushUrl = _Browser_pushUrl;
 var $elm$url$Url$addPort = F2(
 	function (maybePort, starter) {
@@ -5684,7 +5677,7 @@ var $elm$url$Url$toString = function (url) {
 var $author$project$Main$init = F3(
 	function (_v0, url, key) {
 		return _Utils_Tuple2(
-			{activeSchema: $elm$core$Maybe$Nothing, executionNameSearch: $elm$core$Maybe$Nothing, formValues: $author$project$Main$emptyFormValues, granaryExecutions: _List_Nil, granaryTasks: _List_Nil, key: key, route: $author$project$Main$Login, secrets: $elm$core$Maybe$Nothing, secretsUnsubmitted: $elm$core$Maybe$Nothing, selectedExecutions: $elm$core$Set$empty, selectedTask: $elm$core$Maybe$Nothing, taskValidationErrors: $elm$core$Dict$empty, url: url},
+			{executionListModel: $elm$core$Maybe$Nothing, key: key, route: $author$project$Main$Login, secrets: $elm$core$Maybe$Nothing, secretsUnsubmitted: $elm$core$Maybe$Nothing, taskListModel: $elm$core$Maybe$Nothing, url: url},
 			A2(
 				$elm$browser$Browser$Navigation$pushUrl,
 				key,
@@ -5706,12 +5699,30 @@ var $1602$json_schema$Json$Schema$Definitions$ObjectSchema = function (a) {
 	return {$: 'ObjectSchema', a: a};
 };
 var $author$project$Main$TaskList = {$: 'TaskList'};
+var $elm$core$Maybe$andThen = F2(
+	function (callback, maybeValue) {
+		if (maybeValue.$ === 'Just') {
+			var value = maybeValue.a;
+			return callback(value);
+		} else {
+			return $elm$core$Maybe$Nothing;
+		}
+	});
 var $elm$core$Basics$composeL = F3(
 	function (g, f, x) {
 		return g(
 			f(x));
 	});
-var $author$project$Main$GotExecutions = F2(
+var $elm$core$Dict$RBEmpty_elm_builtin = {$: 'RBEmpty_elm_builtin'};
+var $elm$core$Dict$empty = $elm$core$Dict$RBEmpty_elm_builtin;
+var $elm$core$Set$Set_elm_builtin = function (a) {
+	return {$: 'Set_elm_builtin', a: a};
+};
+var $elm$core$Set$empty = $elm$core$Set$Set_elm_builtin($elm$core$Dict$empty);
+var $author$project$Pages$ExecutionList$emptyExecutionListModel = {executionNameSearch: $elm$core$Maybe$Nothing, executions: _List_Nil, forTask: $elm$core$Maybe$Nothing, selectedExecutions: $elm$core$Set$empty};
+var $author$project$Pages$TaskList$emptyFormValues = {executionName: $elm$core$Maybe$Nothing, fromSchema: $elm$core$Dict$empty};
+var $author$project$Pages$TaskList$emptyTaskListModel = {activeSchema: $elm$core$Maybe$Nothing, formValues: $author$project$Pages$TaskList$emptyFormValues, selectedTask: $elm$core$Maybe$Nothing, taskValidationErrors: $elm$core$Dict$empty, tasks: _List_Nil};
+var $author$project$Types$GotExecutions = F2(
 	function (a, b) {
 		return {$: 'GotExecutions', a: a, b: b};
 	});
@@ -5768,7 +5779,7 @@ var $danyx23$elm_uuid$Uuid$toString = function (_v0) {
 	var internalString = _v0.a;
 	return internalString;
 };
-var $author$project$Main$executionsUrl = F2(
+var $author$project$Urls$executionsUrl = F2(
 	function (namesLike, taskId) {
 		var taskSearch = A2(
 			$elm$core$Maybe$map,
@@ -5793,9 +5804,9 @@ var $author$project$Main$executionsUrl = F2(
 		var baseUrl = '/executions';
 		return $elm$core$String$isEmpty(qp) ? baseUrl : (baseUrl + ('?' + qp));
 	});
-var $author$project$Main$apiExecutionsUrl = F2(
+var $author$project$Urls$apiExecutionsUrl = F2(
 	function (namesLike, taskId) {
-		return '/api' + A2($author$project$Main$executionsUrl, namesLike, taskId);
+		return '/api' + A2($author$project$Urls$executionsUrl, namesLike, taskId);
 	});
 var $author$project$Main$GranaryExecution = F7(
 	function (id, taskId, invokedAt, statusReason, results, webhookId, name) {
@@ -7317,7 +7328,7 @@ var $lukewestby$elm_http_builder$HttpBuilder$requestWithMethodAndUrl = F2(
 		};
 	});
 var $lukewestby$elm_http_builder$HttpBuilder$get = $lukewestby$elm_http_builder$HttpBuilder$requestWithMethodAndUrl('GET');
-var $author$project$Main$PaginatedResponse = F3(
+var $author$project$Types$PaginatedResponse = F3(
 	function (page, limit, results) {
 		return {limit: limit, page: page, results: results};
 	});
@@ -7326,7 +7337,7 @@ var $elm$json$Json$Decode$map3 = _Json_map3;
 var $author$project$Main$paginatedDecoder = function (ofDecoder) {
 	return A4(
 		$elm$json$Json$Decode$map3,
-		$author$project$Main$PaginatedResponse,
+		$author$project$Types$PaginatedResponse,
 		A2($elm$json$Json$Decode$field, 'pageSize', $elm$json$Json$Decode$int),
 		A2($elm$json$Json$Decode$field, 'page', $elm$json$Json$Decode$int),
 		A2(
@@ -7524,15 +7535,15 @@ var $author$project$Main$fetchExecutions = F3(
 					$lukewestby$elm_http_builder$HttpBuilder$withExpect,
 					A2(
 						$elm$http$Http$expectJson,
-						$author$project$Main$GotExecutions(taskId),
+						$author$project$Types$GotExecutions(taskId),
 						$author$project$Main$paginatedDecoder($author$project$Main$decoderGranaryExecution)),
 					$lukewestby$elm_http_builder$HttpBuilder$get(
-						A2($author$project$Main$apiExecutionsUrl, namesLike, taskId)))));
+						A2($author$project$Urls$apiExecutionsUrl, namesLike, taskId)))));
 	});
-var $author$project$Main$GotTasks = function (a) {
+var $author$project$Types$GotTasks = function (a) {
 	return {$: 'GotTasks', a: a};
 };
-var $author$project$Main$GranaryTask = F5(
+var $author$project$Types$GranaryTask = F5(
 	function (id, name, validator, jobDefinition, jobQueue) {
 		return {id: id, jobDefinition: jobDefinition, jobQueue: jobQueue, name: name, validator: validator};
 	});
@@ -8257,9 +8268,9 @@ try {
 	};
 } catch ($) {
 	throw 'Some top-level definitions from `Json.Schema.Definitions` are causing infinite recursion:\n\n  ┌─────┐\n  │    itemsDecoder\n  │     ↓\n  │    dependenciesDecoder\n  │     ↓\n  │    decoder\n  │     ↓\n  │    nonEmptyListOfSchemas\n  │     ↓\n  │    schemataDecoder\n  └─────┘\n\nThese errors are very tricky, so read https://elm-lang.org/0.19.1/bad-recursion to learn how to fix it!';}
-var $author$project$Main$decoderGranaryModel = A6(
+var $author$project$Pages$TaskList$decoderGranaryTask = A6(
 	$elm$json$Json$Decode$map5,
-	$author$project$Main$GranaryTask,
+	$author$project$Types$GranaryTask,
 	A2($elm$json$Json$Decode$field, 'id', $danyx23$elm_uuid$Uuid$decoder),
 	A2($elm$json$Json$Decode$field, 'name', $elm$json$Json$Decode$string),
 	A2(
@@ -8277,8 +8288,8 @@ var $author$project$Main$fetchTasks = function (token) {
 				$lukewestby$elm_http_builder$HttpBuilder$withExpect,
 				A2(
 					$elm$http$Http$expectJson,
-					$author$project$Main$GotTasks,
-					$author$project$Main$paginatedDecoder($author$project$Main$decoderGranaryModel)),
+					$author$project$Types$GotTasks,
+					$author$project$Main$paginatedDecoder($author$project$Pages$TaskList$decoderGranaryTask)),
 				$lukewestby$elm_http_builder$HttpBuilder$get('/api/tasks'))));
 };
 var $elm$core$Set$insert = F2(
@@ -8290,7 +8301,7 @@ var $elm$core$Set$insert = F2(
 var $elm$browser$Browser$Navigation$load = _Browser_load;
 var $elm$core$Platform$Cmd$batch = _Platform_batch;
 var $elm$core$Platform$Cmd$none = $elm$core$Platform$Cmd$batch(_List_Nil);
-var $author$project$Main$CreatedExecution = function (a) {
+var $author$project$Types$CreatedExecution = function (a) {
 	return {$: 'CreatedExecution', a: a};
 };
 var $elm$json$Json$Encode$string = _Json_wrap;
@@ -8343,7 +8354,7 @@ var $author$project$Main$postExecution = F2(
 		return $lukewestby$elm_http_builder$HttpBuilder$request(
 			A2(
 				$lukewestby$elm_http_builder$HttpBuilder$withExpect,
-				A2($elm$http$Http$expectJson, $author$project$Main$CreatedExecution, $author$project$Main$decoderGranaryExecution),
+				A2($elm$http$Http$expectJson, $author$project$Types$CreatedExecution, $author$project$Main$decoderGranaryExecution),
 				A2(
 					$lukewestby$elm_http_builder$HttpBuilder$withBearerToken,
 					token,
@@ -8502,15 +8513,6 @@ var $elm$core$Set$remove = F2(
 		var dict = _v0.a;
 		return $elm$core$Set$Set_elm_builtin(
 			A2($elm$core$Dict$remove, key, dict));
-	});
-var $elm$core$Maybe$andThen = F2(
-	function (callback, maybeValue) {
-		if (maybeValue.$ === 'Just') {
-			var value = maybeValue.a;
-			return callback(value);
-		} else {
-			return $elm$core$Maybe$Nothing;
-		}
 	});
 var $elm$url$Url$Parser$Internal$Parser = function (a) {
 	return {$: 'Parser', a: a};
@@ -8688,7 +8690,7 @@ var $author$project$Main$routeParser = function () {
 				$elm$url$Url$Parser$s('tasks'))
 			]));
 }();
-var $author$project$Main$showType = function (t) {
+var $author$project$Pages$TaskList$showType = function (t) {
 	switch (t.$) {
 		case 'SingleType':
 			switch (t.a.$) {
@@ -8718,7 +8720,7 @@ var $author$project$Main$showType = function (t) {
 			return 'any';
 		case 'NullableType':
 			var st = t.a;
-			return 'Maybe ' + $author$project$Main$showType(
+			return 'Maybe ' + $author$project$Pages$TaskList$showType(
 				$1602$json_schema$Json$Schema$Definitions$SingleType(st));
 		default:
 			var sts = t.a;
@@ -8731,7 +8733,7 @@ var $author$project$Main$showType = function (t) {
 					', ',
 					A2(
 						$elm$core$List$map,
-						A2($elm$core$Basics$composeL, $author$project$Main$showType, $1602$json_schema$Json$Schema$Definitions$SingleType),
+						A2($elm$core$Basics$composeL, $author$project$Pages$TaskList$showType, $1602$json_schema$Json$Schema$Definitions$SingleType),
 						sts)));
 	}
 };
@@ -8767,6 +8769,22 @@ var $elm$core$Dict$foldl = F3(
 var $elm$core$Dict$union = F2(
 	function (t1, t2) {
 		return A3($elm$core$Dict$foldl, $elm$core$Dict$insert, t2, t1);
+	});
+var $author$project$Main$updateExecutionListModel = F2(
+	function (f, mod) {
+		var baseExecutionListModel = mod.executionListModel;
+		var updated = A2($elm$core$Maybe$map, f, baseExecutionListModel);
+		return _Utils_update(
+			mod,
+			{executionListModel: updated});
+	});
+var $author$project$Main$updateTaskListModel = F2(
+	function (f, mod) {
+		var baseTaskListModel = mod.taskListModel;
+		var updated = A2($elm$core$Maybe$map, f, baseTaskListModel);
+		return _Utils_update(
+			mod,
+			{taskListModel: updated});
 	});
 var $elm$core$List$filter = F2(
 	function (isGood, list) {
@@ -10836,22 +10854,34 @@ var $author$project$Main$update = F2(
 			case 'TaskSelect':
 				var task = msg.a;
 				return _Utils_Tuple2(
-					_Utils_update(
-						model,
-						{
-							activeSchema: $elm$core$Maybe$Just(task.validator),
-							formValues: $author$project$Main$emptyFormValues,
-							selectedTask: $elm$core$Maybe$Just(task),
-							taskValidationErrors: $elm$core$Dict$empty
-						}),
+					A2(
+						$author$project$Main$updateTaskListModel,
+						function (tlm) {
+							return _Utils_update(
+								tlm,
+								{
+									activeSchema: $elm$core$Maybe$Just(task.validator),
+									formValues: $author$project$Pages$TaskList$emptyFormValues,
+									selectedTask: $elm$core$Maybe$Just(task),
+									taskValidationErrors: $elm$core$Dict$empty
+								});
+						},
+						model),
 					$elm$core$Platform$Cmd$none);
 			case 'GotTasks':
 				if (msg.a.$ === 'Ok') {
 					var tasks = msg.a.a;
+					var withTasks = _Utils_update(
+						$author$project$Pages$TaskList$emptyTaskListModel,
+						{tasks: tasks.results});
 					return _Utils_Tuple2(
 						_Utils_update(
 							model,
-							{granaryTasks: tasks.results, route: $author$project$Main$TaskList, secretsUnsubmitted: $elm$core$Maybe$Nothing}),
+							{
+								route: $author$project$Main$TaskList,
+								secretsUnsubmitted: $elm$core$Maybe$Nothing,
+								taskListModel: $elm$core$Maybe$Just(withTasks)
+							}),
 						$elm$core$Platform$Cmd$none);
 				} else {
 					return _Utils_Tuple2(model, $elm$core$Platform$Cmd$none);
@@ -10860,12 +10890,26 @@ var $author$project$Main$update = F2(
 				if (msg.b.$ === 'Ok') {
 					var taskId = msg.a;
 					var executionsPage = msg.b.a;
+					var withExecutions = A2(
+						$elm$core$Maybe$withDefault,
+						_Utils_update(
+							$author$project$Pages$ExecutionList$emptyExecutionListModel,
+							{executions: executionsPage.results, forTask: taskId}),
+						A2(
+							$elm$core$Maybe$map,
+							function (elm) {
+								return _Utils_update(
+									elm,
+									{executions: executionsPage.results, forTask: taskId});
+							},
+							model.executionListModel));
 					return _Utils_Tuple2(
 						_Utils_update(
 							model,
 							{
-								granaryExecutions: executionsPage.results,
-								route: $author$project$Main$ExecutionList(taskId)
+								executionListModel: $elm$core$Maybe$Just(withExecutions),
+								route: $author$project$Main$ExecutionList(taskId),
+								taskListModel: $elm$core$Maybe$Nothing
 							}),
 						$elm$core$Platform$Cmd$none);
 				} else {
@@ -10891,9 +10935,7 @@ var $author$project$Main$update = F2(
 			case 'CreatedExecution':
 				if (msg.a.$ === 'Ok') {
 					return _Utils_Tuple2(
-						_Utils_update(
-							model,
-							{formValues: $author$project$Main$emptyFormValues}),
+						model,
 						A2(
 							$elm$browser$Browser$Navigation$pushUrl,
 							model.key,
@@ -10908,7 +10950,12 @@ var $author$project$Main$update = F2(
 										function ($) {
 											return $.id;
 										}),
-									model.selectedTask))));
+									A2(
+										$elm$core$Maybe$andThen,
+										function ($) {
+											return $.selectedTask;
+										},
+										model.taskListModel)))));
 				} else {
 					return _Utils_Tuple2(model, $elm$core$Platform$Cmd$none);
 				}
@@ -10929,7 +10976,7 @@ var $author$project$Main$update = F2(
 								[
 									{
 									details: $1602$json_schema$Json$Schema$Validation$InvalidType(
-										'Expected ' + ($author$project$Main$showType(validateOpts.schema.type_) + ' 😟')),
+										'Expected ' + ($author$project$Pages$TaskList$showType(validateOpts.schema.type_) + ' 😟')),
 									jsonPointer: A2(
 										$1602$json_schema$Json$Schema$Validation$JsonPointer,
 										'',
@@ -10940,7 +10987,15 @@ var $author$project$Main$update = F2(
 					}
 				}();
 				if (validation.$ === 'Ok') {
-					var formValues = model.formValues;
+					var formValues = A2(
+						$elm$core$Maybe$withDefault,
+						$author$project$Pages$TaskList$emptyFormValues,
+						A2(
+							$elm$core$Maybe$map,
+							function ($) {
+								return $.formValues;
+							},
+							model.taskListModel));
 					var newFormValues = _Utils_update(
 						formValues,
 						{
@@ -10949,17 +11004,38 @@ var $author$project$Main$update = F2(
 								A2($elm$core$Dict$singleton, validateOpts.fieldName, validateOpts.fieldValue),
 								formValues.fromSchema)
 						});
-					return _Utils_Tuple2(
-						_Utils_update(
-							model,
-							{
-								formValues: newFormValues,
-								taskValidationErrors: A2($elm$core$Dict$remove, validateOpts.fieldName, model.taskValidationErrors)
-							}),
-						$elm$core$Platform$Cmd$none);
+					var baseValidationErrors = A2(
+						$elm$core$Maybe$withDefault,
+						$elm$core$Dict$empty,
+						A2(
+							$elm$core$Maybe$map,
+							function ($) {
+								return $.taskValidationErrors;
+							},
+							model.taskListModel));
+					var updatedTlm = A2(
+						$author$project$Main$updateTaskListModel,
+						function (tlm) {
+							return _Utils_update(
+								tlm,
+								{
+									formValues: newFormValues,
+									taskValidationErrors: A2($elm$core$Dict$remove, validateOpts.fieldName, baseValidationErrors)
+								});
+						},
+						model);
+					return _Utils_Tuple2(updatedTlm, $elm$core$Platform$Cmd$none);
 				} else {
 					var errs = validation.a;
-					var formValues = model.formValues;
+					var formValues = A2(
+						$elm$core$Maybe$withDefault,
+						$author$project$Pages$TaskList$emptyFormValues,
+						A2(
+							$elm$core$Maybe$map,
+							function ($) {
+								return $.formValues;
+							},
+							model.taskListModel));
 					var newFormValues = _Utils_update(
 						formValues,
 						{
@@ -10968,17 +11044,21 @@ var $author$project$Main$update = F2(
 								A2($elm$core$Dict$singleton, validateOpts.fieldName, validateOpts.fieldValue),
 								formValues.fromSchema)
 						});
-					return _Utils_Tuple2(
-						_Utils_update(
-							model,
-							{
-								formValues: newFormValues,
-								taskValidationErrors: A2(
-									$elm$core$Dict$union,
-									A2($elm$core$Dict$singleton, validateOpts.fieldName, errs),
-									model.taskValidationErrors)
-							}),
-						$elm$core$Platform$Cmd$none);
+					var updatedTlm = A2(
+						$author$project$Main$updateTaskListModel,
+						function (tlm) {
+							return _Utils_update(
+								tlm,
+								{
+									formValues: newFormValues,
+									taskValidationErrors: A2(
+										$elm$core$Dict$union,
+										A2($elm$core$Dict$singleton, validateOpts.fieldName, errs),
+										tlm.taskValidationErrors)
+								});
+						},
+						model);
+					return _Utils_Tuple2(updatedTlm, $elm$core$Platform$Cmd$none);
 				}
 			case 'CreateExecution':
 				var executionCreate = msg.a;
@@ -10988,22 +11068,39 @@ var $author$project$Main$update = F2(
 			case 'ToggleShowAssets':
 				var executionId = msg.a;
 				var stringExecutionId = $danyx23$elm_uuid$Uuid$toString(executionId);
-				var selectedExecutions = model.selectedExecutions;
-				return _Utils_Tuple2(
-					_Utils_update(
-						model,
-						{
-							selectedExecutions: A2($elm$core$Set$member, stringExecutionId, selectedExecutions) ? A2($elm$core$Set$remove, stringExecutionId, selectedExecutions) : A2($elm$core$Set$insert, stringExecutionId, selectedExecutions)
-						}),
-					$elm$core$Platform$Cmd$none);
+				var selectedExecutions = A2(
+					$elm$core$Maybe$withDefault,
+					$elm$core$Set$empty,
+					A2(
+						$elm$core$Maybe$map,
+						function ($) {
+							return $.selectedExecutions;
+						},
+						model.executionListModel));
+				var newSelected = A2($elm$core$Set$member, stringExecutionId, selectedExecutions) ? A2($elm$core$Set$remove, stringExecutionId, selectedExecutions) : A2($elm$core$Set$insert, stringExecutionId, selectedExecutions);
+				var updatedElm = A2(
+					$author$project$Main$updateExecutionListModel,
+					function (elm) {
+						return _Utils_update(
+							elm,
+							{selectedExecutions: newSelected});
+					},
+					model);
+				return _Utils_Tuple2(updatedElm, $elm$core$Platform$Cmd$none);
 			case 'SearchExecutionName':
 				var s = msg.a;
+				var updatedElm = A2(
+					$author$project$Main$updateExecutionListModel,
+					function (elm) {
+						return _Utils_update(
+							elm,
+							{
+								executionNameSearch: $elm$core$Maybe$Just(s)
+							});
+					},
+					model);
 				return _Utils_Tuple2(
-					_Utils_update(
-						model,
-						{
-							executionNameSearch: $elm$core$Maybe$Just(s)
-						}),
+					updatedElm,
 					A2(
 						$elm$core$Maybe$withDefault,
 						$elm$core$Platform$Cmd$none,
@@ -11013,11 +11110,11 @@ var $author$project$Main$update = F2(
 								$author$project$Main$fetchExecutions,
 								$elm$core$Maybe$Just(s),
 								A2(
-									$elm$core$Maybe$map,
+									$elm$core$Maybe$andThen,
 									function ($) {
-										return $.id;
+										return $.forTask;
 									},
-									model.selectedTask)),
+									model.executionListModel)),
 							model.secrets)));
 			case 'AddTokenParam':
 				var token = msg.a;
@@ -11058,21 +11155,33 @@ var $author$project$Main$update = F2(
 				return _Utils_Tuple2(
 					_Utils_update(
 						model,
-						{selectedTask: $elm$core$Maybe$Nothing}),
+						{taskListModel: $elm$core$Maybe$Nothing}),
 					A2($elm$browser$Browser$Navigation$pushUrl, model.key, '/tasks'));
 			default:
 				var s = msg.a;
-				var formValues = model.formValues;
+				var formValues = A2(
+					$elm$core$Maybe$withDefault,
+					$author$project$Pages$TaskList$emptyFormValues,
+					A2(
+						$elm$core$Maybe$map,
+						function ($) {
+							return $.formValues;
+						},
+						model.taskListModel));
 				var newFormValues = _Utils_update(
 					formValues,
 					{
 						executionName: $elm$core$Maybe$Just(s)
 					});
-				return _Utils_Tuple2(
-					_Utils_update(
-						model,
-						{formValues: newFormValues}),
-					$elm$core$Platform$Cmd$none);
+				var updatedTlm = A2(
+					$author$project$Main$updateTaskListModel,
+					function (tlm) {
+						return _Utils_update(
+							tlm,
+							{formValues: newFormValues});
+					},
+					model);
+				return _Utils_Tuple2(updatedTlm, $elm$core$Platform$Cmd$none);
 		}
 	});
 var $mdgriffith$elm_ui$Internal$Model$AlignX = function (a) {
@@ -16376,7 +16485,7 @@ var $mdgriffith$elm_ui$Element$column = F2(
 						attrs))),
 			$mdgriffith$elm_ui$Internal$Model$Unkeyed(children));
 	});
-var $author$project$Main$ToggleShowAssets = function (a) {
+var $author$project$Types$ToggleShowAssets = function (a) {
 	return {$: 'ToggleShowAssets', a: a};
 };
 var $mdgriffith$elm_ui$Internal$Model$Button = {$: 'Button'};
@@ -16617,32 +16726,32 @@ var $mdgriffith$elm_ui$Element$rgb255 = F3(
 	function (red, green, blue) {
 		return A4($mdgriffith$elm_ui$Internal$Model$Rgba, red / 255, green / 255, blue / 255, 1);
 	});
-var $author$project$Main$secondary = A3($mdgriffith$elm_ui$Element$rgb255, 246, 141, 17);
+var $author$project$Styled$primary = A3($mdgriffith$elm_ui$Element$rgb255, 75, 59, 64);
 var $mdgriffith$elm_ui$Internal$Model$Text = function (a) {
 	return {$: 'Text', a: a};
 };
 var $mdgriffith$elm_ui$Element$text = function (content) {
 	return $mdgriffith$elm_ui$Internal$Model$Text(content);
 };
-var $author$project$Main$styledSecondaryText = F2(
+var $author$project$Styled$styledPrimaryText = F2(
 	function (attrs, s) {
 		return A2(
 			$mdgriffith$elm_ui$Element$el,
 			A2(
 				$elm$core$List$cons,
-				$mdgriffith$elm_ui$Element$Font$color($author$project$Main$secondary),
+				$mdgriffith$elm_ui$Element$Font$color($author$project$Styled$primary),
 				attrs),
 			$mdgriffith$elm_ui$Element$text(s));
 	});
 var $mdgriffith$elm_ui$Element$Font$underline = $mdgriffith$elm_ui$Internal$Model$htmlClass($mdgriffith$elm_ui$Internal$Style$classes.underline);
-var $author$project$Main$executionAssetsList = $elm$core$List$map(
+var $author$project$Pages$ExecutionList$executionAssetsList = $elm$core$List$map(
 	function (asset) {
 		return A2(
 			$mdgriffith$elm_ui$Element$link,
 			_List_Nil,
 			{
 				label: A2(
-					$author$project$Main$styledSecondaryText,
+					$author$project$Styled$styledPrimaryText,
 					_List_fromArray(
 						[$mdgriffith$elm_ui$Element$Font$underline]),
 					A2(
@@ -16673,18 +16782,7 @@ var $mdgriffith$elm_ui$Element$row = F2(
 						attrs))),
 			$mdgriffith$elm_ui$Internal$Model$Unkeyed(children));
 	});
-var $author$project$Main$primary = A3($mdgriffith$elm_ui$Element$rgb255, 75, 59, 64);
-var $author$project$Main$styledPrimaryText = F2(
-	function (attrs, s) {
-		return A2(
-			$mdgriffith$elm_ui$Element$el,
-			A2(
-				$elm$core$List$cons,
-				$mdgriffith$elm_ui$Element$Font$color($author$project$Main$primary),
-				attrs),
-			$mdgriffith$elm_ui$Element$text(s));
-	});
-var $author$project$Main$executionAssets = F2(
+var $author$project$Pages$ExecutionList$executionAssets = F2(
 	function (showAssets, execution) {
 		return $elm$core$List$isEmpty(execution.results) ? _List_Nil : A2(
 			$elm$core$List$cons,
@@ -16699,11 +16797,11 @@ var $author$project$Main$executionAssets = F2(
 						{
 							label: $mdgriffith$elm_ui$Element$text('➕'),
 							onPress: $elm$core$Maybe$Just(
-								$author$project$Main$ToggleShowAssets(execution.id))
+								$author$project$Types$ToggleShowAssets(execution.id))
 						}),
-						A2($author$project$Main$styledPrimaryText, _List_Nil, ' Show assets')
+						A2($author$project$Styled$styledPrimaryText, _List_Nil, ' Show assets')
 					])),
-			showAssets ? $author$project$Main$executionAssetsList(execution.results) : _List_Nil);
+			showAssets ? $author$project$Pages$ExecutionList$executionAssetsList(execution.results) : _List_Nil);
 	});
 var $mdgriffith$elm_ui$Internal$Model$Fill = function (a) {
 	return {$: 'Fill', a: a};
@@ -16900,7 +16998,7 @@ var $mdgriffith$elm_ui$Element$spacing = function (x) {
 			x,
 			x));
 };
-var $author$project$Main$toEmoji = function (execution) {
+var $author$project$Pages$ExecutionList$toEmoji = function (execution) {
 	var _v0 = _Utils_Tuple2(execution.statusReason, execution.results);
 	if (_v0.a.$ === 'Just') {
 		return '❌';
@@ -16913,7 +17011,7 @@ var $author$project$Main$toEmoji = function (execution) {
 		}
 	}
 };
-var $author$project$Main$executionCard = F2(
+var $author$project$Pages$ExecutionList$executionCard = F2(
 	function (showAssets, execution) {
 		return A2(
 			$mdgriffith$elm_ui$Element$row,
@@ -16944,7 +17042,7 @@ var $author$project$Main$executionCard = F2(
 								_List_Nil,
 								_List_fromArray(
 									[
-										A2($author$project$Main$styledPrimaryText, _List_Nil, execution.name)
+										A2($author$project$Styled$styledPrimaryText, _List_Nil, execution.name)
 									])),
 								A2(
 								$mdgriffith$elm_ui$Element$row,
@@ -16952,173 +17050,15 @@ var $author$project$Main$executionCard = F2(
 								_List_fromArray(
 									[
 										A2(
-										$author$project$Main$styledPrimaryText,
+										$author$project$Styled$styledPrimaryText,
 										_List_Nil,
-										'Status: ' + $author$project$Main$toEmoji(execution))
+										'Status: ' + $author$project$Pages$ExecutionList$toEmoji(execution))
 									]))
 							]),
-						A2($author$project$Main$executionAssets, showAssets, execution)))
+						A2($author$project$Pages$ExecutionList$executionAssets, showAssets, execution)))
 				]));
 	});
-var $mdgriffith$elm_ui$Internal$Model$CenterY = {$: 'CenterY'};
-var $mdgriffith$elm_ui$Element$centerY = $mdgriffith$elm_ui$Internal$Model$AlignY($mdgriffith$elm_ui$Internal$Model$CenterY);
-var $mdgriffith$elm_ui$Element$fillPortion = $mdgriffith$elm_ui$Internal$Model$Fill;
-var $author$project$Main$GoHome = {$: 'GoHome'};
-var $author$project$Main$homeLink = A2(
-	$mdgriffith$elm_ui$Element$Input$button,
-	_List_Nil,
-	{
-		label: $mdgriffith$elm_ui$Element$text('🏠'),
-		onPress: $elm$core$Maybe$Just($author$project$Main$GoHome)
-	});
-var $elm$html$Html$Attributes$alt = $elm$html$Html$Attributes$stringProperty('alt');
-var $elm$html$Html$Attributes$src = function (url) {
-	return A2(
-		$elm$html$Html$Attributes$stringProperty,
-		'src',
-		_VirtualDom_noJavaScriptOrHtmlUri(url));
-};
-var $mdgriffith$elm_ui$Element$image = F2(
-	function (attrs, _v0) {
-		var src = _v0.src;
-		var description = _v0.description;
-		var imageAttributes = A2(
-			$elm$core$List$filter,
-			function (a) {
-				switch (a.$) {
-					case 'Width':
-						return true;
-					case 'Height':
-						return true;
-					default:
-						return false;
-				}
-			},
-			attrs);
-		return A4(
-			$mdgriffith$elm_ui$Internal$Model$element,
-			$mdgriffith$elm_ui$Internal$Model$asEl,
-			$mdgriffith$elm_ui$Internal$Model$div,
-			A2(
-				$elm$core$List$cons,
-				$mdgriffith$elm_ui$Internal$Model$htmlClass($mdgriffith$elm_ui$Internal$Style$classes.imageContainer),
-				attrs),
-			$mdgriffith$elm_ui$Internal$Model$Unkeyed(
-				_List_fromArray(
-					[
-						A4(
-						$mdgriffith$elm_ui$Internal$Model$element,
-						$mdgriffith$elm_ui$Internal$Model$asEl,
-						$mdgriffith$elm_ui$Internal$Model$NodeName('img'),
-						_Utils_ap(
-							_List_fromArray(
-								[
-									$mdgriffith$elm_ui$Internal$Model$Attr(
-									$elm$html$Html$Attributes$src(src)),
-									$mdgriffith$elm_ui$Internal$Model$Attr(
-									$elm$html$Html$Attributes$alt(description))
-								]),
-							imageAttributes),
-						$mdgriffith$elm_ui$Internal$Model$Unkeyed(_List_Nil))
-					])));
-	});
-var $author$project$Main$logo = F2(
-	function (attrs, maxSize) {
-		return A2(
-			$mdgriffith$elm_ui$Element$image,
-			_Utils_ap(
-				_List_fromArray(
-					[
-						$mdgriffith$elm_ui$Element$height(
-						A2(
-							$mdgriffith$elm_ui$Element$maximum,
-							maxSize,
-							A2(
-								$mdgriffith$elm_ui$Element$minimum,
-								100,
-								$mdgriffith$elm_ui$Element$fillPortion(1)))),
-						$mdgriffith$elm_ui$Element$padding(10)
-					]),
-				attrs),
-			{description: 'Granary logo', src: 'logo.svg'});
-	});
-var $author$project$Main$AddTokenParam = function (a) {
-	return {$: 'AddTokenParam', a: a};
-};
-var $author$project$Main$pageLink = function (secrets) {
-	return A2(
-		$mdgriffith$elm_ui$Element$Input$button,
-		_List_Nil,
-		{
-			label: $mdgriffith$elm_ui$Element$text('🔗'),
-			onPress: A2($elm$core$Maybe$map, $author$project$Main$AddTokenParam, secrets)
-		});
-};
-var $author$project$Main$logoTop = F2(
-	function (secrets, rest) {
-		return A2(
-			$mdgriffith$elm_ui$Element$column,
-			_List_fromArray(
-				[
-					$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill),
-					$mdgriffith$elm_ui$Element$centerX
-				]),
-			_Utils_ap(
-				_List_fromArray(
-					[
-						A2(
-						$mdgriffith$elm_ui$Element$row,
-						_List_fromArray(
-							[
-								$mdgriffith$elm_ui$Element$centerX,
-								$mdgriffith$elm_ui$Element$width(
-								A2($mdgriffith$elm_ui$Element$maximum, 400, $mdgriffith$elm_ui$Element$fill))
-							]),
-						_List_fromArray(
-							[
-								A2(
-								$mdgriffith$elm_ui$Element$column,
-								_List_fromArray(
-									[
-										$mdgriffith$elm_ui$Element$width(
-										$mdgriffith$elm_ui$Element$fillPortion(9)),
-										$mdgriffith$elm_ui$Element$height($mdgriffith$elm_ui$Element$fill)
-									]),
-								_List_fromArray(
-									[
-										A2(
-										$author$project$Main$logo,
-										_List_fromArray(
-											[
-												$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill)
-											]),
-										100)
-									])),
-								A2(
-								$mdgriffith$elm_ui$Element$column,
-								_List_fromArray(
-									[
-										$mdgriffith$elm_ui$Element$width(
-										$mdgriffith$elm_ui$Element$fillPortion(1)),
-										$mdgriffith$elm_ui$Element$height($mdgriffith$elm_ui$Element$fill)
-									]),
-								_List_fromArray(
-									[
-										A2(
-										$mdgriffith$elm_ui$Element$row,
-										_List_fromArray(
-											[$mdgriffith$elm_ui$Element$centerY]),
-										_List_fromArray(
-											[
-												$author$project$Main$pageLink(secrets),
-												$author$project$Main$homeLink
-											]))
-									]))
-							]))
-					]),
-				rest));
-	});
-var $author$project$Main$SearchExecutionName = function (a) {
+var $author$project$Types$SearchExecutionName = function (a) {
 	return {$: 'SearchExecutionName', a: a};
 };
 var $elm$core$List$singleton = function (value) {
@@ -17272,10 +17212,11 @@ var $mdgriffith$elm_ui$Element$Input$Placeholder = F2(
 		return {$: 'Placeholder', a: a, b: b};
 	});
 var $mdgriffith$elm_ui$Element$Input$placeholder = $mdgriffith$elm_ui$Element$Input$Placeholder;
-var $author$project$Main$secondaryShadow = $mdgriffith$elm_ui$Element$Border$shadow(
+var $author$project$Styled$secondary = A3($mdgriffith$elm_ui$Element$rgb255, 246, 141, 17);
+var $author$project$Styled$secondaryShadow = $mdgriffith$elm_ui$Element$Border$shadow(
 	{
 		blur: 3,
-		color: $author$project$Main$secondary,
+		color: $author$project$Styled$secondary,
 		offset: _Utils_Tuple2(0.1, 0.1),
 		size: 2
 	});
@@ -18112,7 +18053,7 @@ var $mdgriffith$elm_ui$Element$Input$text = $mdgriffith$elm_ui$Element$Input$tex
 		spellchecked: false,
 		type_: $mdgriffith$elm_ui$Element$Input$TextInputNode('text')
 	});
-var $author$project$Main$textInput = F5(
+var $author$project$Styled$textInput = F5(
 	function (attrs, f, maybeText, placeholder, label) {
 		return A2(
 			$mdgriffith$elm_ui$Element$Input$text,
@@ -18120,7 +18061,7 @@ var $author$project$Main$textInput = F5(
 				$elm$core$List$cons,
 				$mdgriffith$elm_ui$Element$focused(
 					_List_fromArray(
-						[$author$project$Main$secondaryShadow])),
+						[$author$project$Styled$secondaryShadow])),
 				attrs),
 			{
 				label: $mdgriffith$elm_ui$Element$Input$labelHidden(label),
@@ -18133,7 +18074,7 @@ var $author$project$Main$textInput = F5(
 				text: A2($elm$core$Maybe$withDefault, '', maybeText)
 			});
 	});
-var $author$project$Main$nameSearchInput = function (currValue) {
+var $author$project$Pages$ExecutionList$nameSearchInput = function (currValue) {
 	return A2(
 		$mdgriffith$elm_ui$Element$row,
 		_List_fromArray(
@@ -18142,17 +18083,17 @@ var $author$project$Main$nameSearchInput = function (currValue) {
 			]),
 		$elm$core$List$singleton(
 			A5(
-				$author$project$Main$textInput,
+				$author$project$Styled$textInput,
 				_List_fromArray(
 					[
 						$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill)
 					]),
-				$author$project$Main$SearchExecutionName,
+				$author$project$Types$SearchExecutionName,
 				currValue,
 				'Name like',
 				'Search')));
 };
-var $author$project$Main$executionList = function (model) {
+var $author$project$Pages$ExecutionList$executionList = function (model) {
 	var showAssets = function (execution) {
 		return A2(
 			$elm$core$Set$member,
@@ -18161,28 +18102,22 @@ var $author$project$Main$executionList = function (model) {
 	};
 	var card = function (execution) {
 		return A2(
-			$author$project$Main$executionCard,
+			$author$project$Pages$ExecutionList$executionCard,
 			showAssets(execution),
 			execution);
 	};
 	return A2(
-		$author$project$Main$logoTop,
-		model.secrets,
+		$mdgriffith$elm_ui$Element$column,
 		_List_fromArray(
 			[
-				A2(
-				$mdgriffith$elm_ui$Element$column,
-				_List_fromArray(
-					[
-						$mdgriffith$elm_ui$Element$centerX,
-						$mdgriffith$elm_ui$Element$spacing(10),
-						$mdgriffith$elm_ui$Element$padding(15)
-					]),
-				A2(
-					$elm$core$List$cons,
-					$author$project$Main$nameSearchInput(model.executionNameSearch),
-					A2($elm$core$List$map, card, model.granaryExecutions)))
-			]));
+				$mdgriffith$elm_ui$Element$centerX,
+				$mdgriffith$elm_ui$Element$spacing(10),
+				$mdgriffith$elm_ui$Element$padding(15)
+			]),
+		A2(
+			$elm$core$List$cons,
+			$author$project$Pages$ExecutionList$nameSearchInput(model.executionNameSearch),
+			A2($elm$core$List$map, card, model.executions)));
 };
 var $mdgriffith$elm_ui$Internal$Model$OnlyDynamic = F2(
 	function (a, b) {
@@ -18439,11 +18374,85 @@ var $mdgriffith$elm_ui$Element$layoutWith = F3(
 	});
 var $mdgriffith$elm_ui$Element$layout = $mdgriffith$elm_ui$Element$layoutWith(
 	{options: _List_Nil});
-var $author$project$Main$TokenInput = function (a) {
+var $author$project$Types$TokenInput = function (a) {
 	return {$: 'TokenInput', a: a};
 };
-var $author$project$Main$TokenSubmit = {$: 'TokenSubmit'};
-var $author$project$Main$accent = A3($mdgriffith$elm_ui$Element$rgb255, 253, 233, 135);
+var $author$project$Types$TokenSubmit = {$: 'TokenSubmit'};
+var $mdgriffith$elm_ui$Internal$Model$CenterY = {$: 'CenterY'};
+var $mdgriffith$elm_ui$Element$centerY = $mdgriffith$elm_ui$Internal$Model$AlignY($mdgriffith$elm_ui$Internal$Model$CenterY);
+var $mdgriffith$elm_ui$Element$fillPortion = $mdgriffith$elm_ui$Internal$Model$Fill;
+var $elm$html$Html$Attributes$alt = $elm$html$Html$Attributes$stringProperty('alt');
+var $elm$html$Html$Attributes$src = function (url) {
+	return A2(
+		$elm$html$Html$Attributes$stringProperty,
+		'src',
+		_VirtualDom_noJavaScriptOrHtmlUri(url));
+};
+var $mdgriffith$elm_ui$Element$image = F2(
+	function (attrs, _v0) {
+		var src = _v0.src;
+		var description = _v0.description;
+		var imageAttributes = A2(
+			$elm$core$List$filter,
+			function (a) {
+				switch (a.$) {
+					case 'Width':
+						return true;
+					case 'Height':
+						return true;
+					default:
+						return false;
+				}
+			},
+			attrs);
+		return A4(
+			$mdgriffith$elm_ui$Internal$Model$element,
+			$mdgriffith$elm_ui$Internal$Model$asEl,
+			$mdgriffith$elm_ui$Internal$Model$div,
+			A2(
+				$elm$core$List$cons,
+				$mdgriffith$elm_ui$Internal$Model$htmlClass($mdgriffith$elm_ui$Internal$Style$classes.imageContainer),
+				attrs),
+			$mdgriffith$elm_ui$Internal$Model$Unkeyed(
+				_List_fromArray(
+					[
+						A4(
+						$mdgriffith$elm_ui$Internal$Model$element,
+						$mdgriffith$elm_ui$Internal$Model$asEl,
+						$mdgriffith$elm_ui$Internal$Model$NodeName('img'),
+						_Utils_ap(
+							_List_fromArray(
+								[
+									$mdgriffith$elm_ui$Internal$Model$Attr(
+									$elm$html$Html$Attributes$src(src)),
+									$mdgriffith$elm_ui$Internal$Model$Attr(
+									$elm$html$Html$Attributes$alt(description))
+								]),
+							imageAttributes),
+						$mdgriffith$elm_ui$Internal$Model$Unkeyed(_List_Nil))
+					])));
+	});
+var $author$project$Main$logo = F2(
+	function (attrs, maxSize) {
+		return A2(
+			$mdgriffith$elm_ui$Element$image,
+			_Utils_ap(
+				_List_fromArray(
+					[
+						$mdgriffith$elm_ui$Element$height(
+						A2(
+							$mdgriffith$elm_ui$Element$maximum,
+							maxSize,
+							A2(
+								$mdgriffith$elm_ui$Element$minimum,
+								100,
+								$mdgriffith$elm_ui$Element$fillPortion(1)))),
+						$mdgriffith$elm_ui$Element$padding(10)
+					]),
+				attrs),
+			{description: 'Granary logo', src: 'logo.svg'});
+	});
+var $author$project$Styled$accent = A3($mdgriffith$elm_ui$Element$rgb255, 253, 233, 135);
 var $mdgriffith$elm_ui$Internal$Flag$fontAlignment = $mdgriffith$elm_ui$Internal$Flag$flag(12);
 var $mdgriffith$elm_ui$Element$Font$center = A2($mdgriffith$elm_ui$Internal$Model$Class, $mdgriffith$elm_ui$Internal$Flag$fontAlignment, $mdgriffith$elm_ui$Internal$Style$classes.textCenter);
 var $Orasund$elm_ui_framework$Framework$Color$grey = A3($mdgriffith$elm_ui$Element$rgb255, 122, 122, 122);
@@ -18472,7 +18481,17 @@ var $Orasund$elm_ui_framework$Framework$Button$simple = _Utils_ap(
 					])),
 				A2($mdgriffith$elm_ui$Element$paddingXY, 16, 12)
 			])));
-var $author$project$Main$submitButton = F4(
+var $author$project$Styled$styledSecondaryText = F2(
+	function (attrs, s) {
+		return A2(
+			$mdgriffith$elm_ui$Element$el,
+			A2(
+				$elm$core$List$cons,
+				$mdgriffith$elm_ui$Element$Font$color($author$project$Styled$secondary),
+				attrs),
+			$mdgriffith$elm_ui$Element$text(s));
+	});
+var $author$project$Styled$submitButton = F4(
 	function (predicate, value, hint, msg) {
 		var allowSubmit = predicate(value);
 		return A2(
@@ -18492,17 +18511,17 @@ var $author$project$Main$submitButton = F4(
 							$Orasund$elm_ui_framework$Framework$Button$simple,
 							_List_fromArray(
 								[
-									$mdgriffith$elm_ui$Element$Background$color($author$project$Main$accent),
+									$mdgriffith$elm_ui$Element$Background$color($author$project$Styled$accent),
 									$mdgriffith$elm_ui$Element$centerX,
-									$mdgriffith$elm_ui$Element$Border$color($author$project$Main$primary)
+									$mdgriffith$elm_ui$Element$Border$color($author$project$Styled$primary)
 								])),
 						{
-							label: A2($author$project$Main$styledPrimaryText, _List_Nil, 'Submit'),
+							label: A2($author$project$Styled$styledPrimaryText, _List_Nil, 'Submit'),
 							onPress: allowSubmit ? $elm$core$Maybe$Just(msg) : $elm$core$Maybe$Nothing
 						})),
 				allowSubmit ? _List_Nil : _List_fromArray(
 					[
-						A2($author$project$Main$styledSecondaryText, _List_Nil, hint)
+						A2($author$project$Styled$styledSecondaryText, _List_Nil, hint)
 					])));
 	});
 var $author$project$Main$loginPage = function (model) {
@@ -18535,7 +18554,7 @@ var $author$project$Main$loginPage = function (model) {
 					]),
 				_List_fromArray(
 					[
-						A5($author$project$Main$textInput, _List_Nil, $author$project$Main$TokenInput, model.secretsUnsubmitted, 'Enter a token', 'Token input')
+						A5($author$project$Styled$textInput, _List_Nil, $author$project$Types$TokenInput, model.secretsUnsubmitted, 'Enter a token', 'Token input')
 					])),
 				A2(
 				$mdgriffith$elm_ui$Element$row,
@@ -18546,25 +18565,93 @@ var $author$project$Main$loginPage = function (model) {
 				_List_fromArray(
 					[
 						A4(
-						$author$project$Main$submitButton,
+						$author$project$Styled$submitButton,
 						A2($elm$core$Basics$composeL, $elm$core$Basics$not, $elm$core$String$isEmpty),
 						A2($elm$core$Maybe$withDefault, '', model.secretsUnsubmitted),
 						'Please enter a token',
-						$author$project$Main$TokenSubmit)
+						$author$project$Types$TokenSubmit)
 					]))
 			]));
 };
-var $author$project$Main$CreateExecution = function (a) {
+var $author$project$Types$GoHome = {$: 'GoHome'};
+var $author$project$Main$homeLink = A2(
+	$mdgriffith$elm_ui$Element$Input$button,
+	_List_Nil,
+	{
+		label: $mdgriffith$elm_ui$Element$text('🏠'),
+		onPress: $elm$core$Maybe$Just($author$project$Types$GoHome)
+	});
+var $author$project$Main$logoTop = function (rest) {
+	return A2(
+		$mdgriffith$elm_ui$Element$column,
+		_List_fromArray(
+			[
+				$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill),
+				$mdgriffith$elm_ui$Element$centerX
+			]),
+		_Utils_ap(
+			_List_fromArray(
+				[
+					A2(
+					$mdgriffith$elm_ui$Element$row,
+					_List_fromArray(
+						[
+							$mdgriffith$elm_ui$Element$centerX,
+							$mdgriffith$elm_ui$Element$width(
+							A2($mdgriffith$elm_ui$Element$maximum, 400, $mdgriffith$elm_ui$Element$fill))
+						]),
+					_List_fromArray(
+						[
+							A2(
+							$mdgriffith$elm_ui$Element$column,
+							_List_fromArray(
+								[
+									$mdgriffith$elm_ui$Element$width(
+									$mdgriffith$elm_ui$Element$fillPortion(9)),
+									$mdgriffith$elm_ui$Element$height($mdgriffith$elm_ui$Element$fill)
+								]),
+							_List_fromArray(
+								[
+									A2(
+									$author$project$Main$logo,
+									_List_fromArray(
+										[
+											$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill)
+										]),
+									100)
+								])),
+							A2(
+							$mdgriffith$elm_ui$Element$column,
+							_List_fromArray(
+								[
+									$mdgriffith$elm_ui$Element$width(
+									$mdgriffith$elm_ui$Element$fillPortion(1)),
+									$mdgriffith$elm_ui$Element$height($mdgriffith$elm_ui$Element$fill)
+								]),
+							_List_fromArray(
+								[
+									A2(
+									$mdgriffith$elm_ui$Element$row,
+									_List_fromArray(
+										[$mdgriffith$elm_ui$Element$centerY]),
+									_List_fromArray(
+										[$author$project$Main$homeLink]))
+								]))
+						]))
+				]),
+			rest));
+};
+var $author$project$Types$CreateExecution = function (a) {
 	return {$: 'CreateExecution', a: a};
 };
-var $author$project$Main$isOk = function (res) {
+var $author$project$Pages$TaskList$isOk = function (res) {
 	if (res.$ === 'Ok') {
 		return true;
 	} else {
 		return false;
 	}
 };
-var $author$project$Main$numProperties = function (schema) {
+var $author$project$Pages$TaskList$numProperties = function (schema) {
 	var schemataLength = function (_v1) {
 		var props = _v1.a;
 		return $elm$core$List$length(props);
@@ -18609,7 +18696,7 @@ var $elm$core$Dict$values = function (dict) {
 		_List_Nil,
 		dict);
 };
-var $author$project$Main$allowTaskSubmit = F2(
+var $author$project$Pages$TaskList$allowTaskSubmit = F2(
 	function (schema, formValues) {
 		var _v0 = _Utils_Tuple2(formValues.executionName, schema);
 		if (_v0.a.$ === 'Nothing') {
@@ -18631,23 +18718,23 @@ var $author$project$Main$allowTaskSubmit = F2(
 					true,
 					A2(
 						$elm$core$List$map,
-						$author$project$Main$isOk,
+						$author$project$Pages$TaskList$isOk,
 						$elm$core$Dict$values(formValues.fromSchema))) && _Utils_eq(
 					$elm$core$Dict$size(formValues.fromSchema),
-					$author$project$Main$numProperties(schm)));
+					$author$project$Pages$TaskList$numProperties(schm)));
 			}
 		}
 	});
-var $author$project$Main$NameExecution = function (a) {
+var $author$project$Types$NameExecution = function (a) {
 	return {$: 'NameExecution', a: a};
 };
-var $author$project$Main$ValidateWith = function (a) {
+var $author$project$Types$ValidateWith = function (a) {
 	return {$: 'ValidateWith', a: a};
 };
 var $elm$core$String$fromList = _String_fromList;
-var $author$project$Main$fontRed = $mdgriffith$elm_ui$Element$Font$color(
+var $author$project$Pages$TaskList$fontRed = $mdgriffith$elm_ui$Element$Font$color(
 	A3($mdgriffith$elm_ui$Element$rgb255, 255, 0, 0));
-var $author$project$Main$getErrField = function (err) {
+var $author$project$Pages$TaskList$getErrField = function (err) {
 	var _v0 = err.jsonPointer.path;
 	if (!_v0.b) {
 		return 'ROOT';
@@ -18657,7 +18744,7 @@ var $author$project$Main$getErrField = function (err) {
 			A2($elm$core$List$intersperse, '.', errs));
 	}
 };
-var $author$project$Main$makeErr = function (err) {
+var $author$project$Pages$TaskList$makeErr = function (err) {
 	var _v0 = err.details;
 	switch (_v0.$) {
 		case 'Required':
@@ -18674,7 +18761,7 @@ var $author$project$Main$makeErr = function (err) {
 								A2(
 								$mdgriffith$elm_ui$Element$el,
 								_List_fromArray(
-									[$author$project$Main$fontRed]),
+									[$author$project$Pages$TaskList$fontRed]),
 								$mdgriffith$elm_ui$Element$text(s))
 							]));
 				},
@@ -18702,7 +18789,7 @@ var $author$project$Main$makeErr = function (err) {
 			return _List_fromArray(
 				[
 					$mdgriffith$elm_ui$Element$text(
-					'I can\'t tell what else is wrong with ' + $author$project$Main$getErrField(err))
+					'I can\'t tell what else is wrong with ' + $author$project$Pages$TaskList$getErrField(err))
 				]);
 	}
 };
@@ -18800,7 +18887,7 @@ var $elm$core$Array$fromList = function (list) {
 };
 var $elm$json$Json$Encode$int = _Json_wrap;
 var $elm$json$Json$Encode$null = _Json_encodeNull;
-var $author$project$Main$toResult = F2(
+var $author$project$Pages$TaskList$toResult = F2(
 	function (s, m) {
 		if (m.$ === 'Just') {
 			var v = m.a;
@@ -18809,11 +18896,11 @@ var $author$project$Main$toResult = F2(
 			return $elm$core$Result$Err(s);
 		}
 	});
-var $author$project$Main$encodeValue = F2(
+var $author$project$Pages$TaskList$encodeValue = F2(
 	function (t, s) {
 		encodeValue:
 		while (true) {
-			var defaulter = $author$project$Main$toResult(s);
+			var defaulter = $author$project$Pages$TaskList$toResult(s);
 			switch (t.$) {
 				case 'SingleType':
 					switch (t.a.$) {
@@ -18905,12 +18992,12 @@ var $author$project$Main$encodeValue = F2(
 						$elm$core$List$head(
 							A2(
 								$elm$core$List$filter,
-								$author$project$Main$isOk,
+								$author$project$Pages$TaskList$isOk,
 								A2(
 									$elm$core$List$map,
 									function (st) {
 										return A2(
-											$author$project$Main$encodeValue,
+											$author$project$Pages$TaskList$encodeValue,
 											$1602$json_schema$Json$Schema$Definitions$SingleType(st),
 											s);
 									},
@@ -18918,27 +19005,27 @@ var $author$project$Main$encodeValue = F2(
 			}
 		}
 	});
-var $author$project$Main$toValue = F2(
+var $author$project$Pages$TaskList$toValue = F2(
 	function (schema, s) {
-		return A2($author$project$Main$encodeValue, schema.type_, s);
+		return A2($author$project$Pages$TaskList$encodeValue, schema.type_, s);
 	});
-var $author$project$Main$schemaToForm = F3(
+var $author$project$Pages$TaskList$schemaToForm = F3(
 	function (formValues, errors, schema) {
 		var toInput = function (_v5) {
 			var k = _v5.a;
 			var v = _v5.b;
 			return ($elm$core$String$toLower(k) !== 'task_grid') ? A5(
-				$author$project$Main$textInput,
+				$author$project$Styled$textInput,
 				_List_fromArray(
 					[
 						$mdgriffith$elm_ui$Element$width(
 						A2($mdgriffith$elm_ui$Element$minimum, 300, $mdgriffith$elm_ui$Element$fill))
 					]),
 				function (s) {
-					return $author$project$Main$ValidateWith(
+					return $author$project$Types$ValidateWith(
 						{
 							fieldName: k,
-							fieldValue: A2($author$project$Main$toValue, v, s),
+							fieldValue: A2($author$project$Pages$TaskList$toValue, v, s),
 							schema: v
 						});
 				},
@@ -18963,7 +19050,7 @@ var $author$project$Main$schemaToForm = F3(
 						return $elm$core$Maybe$Nothing;
 					}
 				}(),
-				k + (': ' + $author$project$Main$showType(v.type_)),
+				k + (': ' + $author$project$Pages$TaskList$showType(v.type_)),
 				k) : A2(
 				$mdgriffith$elm_ui$Element$row,
 				_List_Nil,
@@ -18976,7 +19063,7 @@ var $author$project$Main$schemaToForm = F3(
 			var k = _v3.a;
 			return A2(
 				$elm$core$List$concatMap,
-				$author$project$Main$makeErr,
+				$author$project$Pages$TaskList$makeErr,
 				A2(
 					$elm$core$Maybe$withDefault,
 					_List_Nil,
@@ -19032,7 +19119,7 @@ var $author$project$Main$schemaToForm = F3(
 			_List_Nil,
 			A2($elm$core$Maybe$map, makeInput, schema.properties));
 	});
-var $author$project$Main$executionInput = F3(
+var $author$project$Pages$TaskList$executionInput = F3(
 	function (formValues, errors, task) {
 		var _v0 = task.validator;
 		if (_v0.$ === 'BooleanSchema') {
@@ -19048,23 +19135,23 @@ var $author$project$Main$executionInput = F3(
 			return A2(
 				$elm$core$List$cons,
 				A5(
-					$author$project$Main$textInput,
+					$author$project$Styled$textInput,
 					_List_fromArray(
 						[
 							$mdgriffith$elm_ui$Element$width(
 							A2($mdgriffith$elm_ui$Element$minimum, 300, $mdgriffith$elm_ui$Element$fill))
 						]),
-					$author$project$Main$NameExecution,
+					$author$project$Types$NameExecution,
 					formValues.executionName,
 					'Execution name',
 					'New execution name'),
-				A3($author$project$Main$schemaToForm, formValues.fromSchema, errors, subSchema));
+				A3($author$project$Pages$TaskList$schemaToForm, formValues.fromSchema, errors, subSchema));
 		}
 	});
-var $author$project$Main$TaskSelect = function (a) {
+var $author$project$Types$TaskSelect = function (a) {
 	return {$: 'TaskSelect', a: a};
 };
-var $author$project$Main$tasksLink = F2(
+var $author$project$Pages$TaskList$tasksLink = F2(
 	function (selectedId, task) {
 		return _Utils_eq(
 			selectedId,
@@ -19086,19 +19173,19 @@ var $author$project$Main$tasksLink = F2(
 							_List_Nil,
 							{
 								label: A2(
-									$author$project$Main$styledSecondaryText,
+									$author$project$Styled$styledSecondaryText,
 									_List_fromArray(
 										[$mdgriffith$elm_ui$Element$Font$underline]),
 									'Executions'),
 								url: A2(
-									$author$project$Main$executionsUrl,
+									$author$project$Urls$executionsUrl,
 									$elm$core$Maybe$Nothing,
 									$elm$core$Maybe$Just(task.id))
 							})
 						]))
 				])) : A2($mdgriffith$elm_ui$Element$row, _List_Nil, _List_Nil);
 	});
-var $author$project$Main$taskCard = F2(
+var $author$project$Pages$TaskList$taskCard = F2(
 	function (selectedId, task) {
 		return A2(
 			$mdgriffith$elm_ui$Element$column,
@@ -19115,11 +19202,11 @@ var $author$project$Main$taskCard = F2(
 					$mdgriffith$elm_ui$Element$row,
 					A2(
 						$elm$core$List$cons,
-						$mdgriffith$elm_ui$Element$Font$color($author$project$Main$primary),
+						$mdgriffith$elm_ui$Element$Font$color($author$project$Styled$primary),
 						_Utils_eq(
 							$elm$core$Maybe$Just(task.id),
 							selectedId) ? _List_fromArray(
-							[$author$project$Main$secondaryShadow]) : _List_Nil),
+							[$author$project$Styled$secondaryShadow]) : _List_Nil),
 					_List_fromArray(
 						[
 							A2(
@@ -19128,17 +19215,17 @@ var $author$project$Main$taskCard = F2(
 							{
 								label: $mdgriffith$elm_ui$Element$text(task.name),
 								onPress: $elm$core$Maybe$Just(
-									$author$project$Main$TaskSelect(task))
+									$author$project$Types$TaskSelect(task))
 							})
 						])),
-					A2($author$project$Main$tasksLink, selectedId, task)
+					A2($author$project$Pages$TaskList$tasksLink, selectedId, task)
 				]));
 	});
-var $author$project$Main$ExecutionCreate = F3(
+var $author$project$Pages$TaskList$ExecutionCreate = F3(
 	function (name, taskId, _arguments) {
 		return {_arguments: _arguments, name: name, taskId: taskId};
 	});
-var $author$project$Main$toExecutionCreate = F3(
+var $author$project$Pages$TaskList$toExecutionCreate = F3(
 	function (fallbackName, taskId, formValues) {
 		var goodFields = A2(
 			$elm$core$List$filterMap,
@@ -19155,112 +19242,130 @@ var $author$project$Main$toExecutionCreate = F3(
 			$elm$core$Dict$toList(formValues.fromSchema));
 		var executionName = A2($elm$core$Maybe$withDefault, fallbackName, formValues.executionName);
 		return A3(
-			$author$project$Main$ExecutionCreate,
+			$author$project$Pages$TaskList$ExecutionCreate,
 			executionName,
 			taskId,
 			$elm$json$Json$Encode$object(goodFields));
 	});
-var $author$project$Main$taskList = function (model) {
+var $author$project$Pages$TaskList$taskList = function (model) {
 	return A2(
-		$author$project$Main$logoTop,
-		model.secrets,
+		$mdgriffith$elm_ui$Element$row,
+		_List_fromArray(
+			[$mdgriffith$elm_ui$Element$centerX]),
 		_List_fromArray(
 			[
 				A2(
-				$mdgriffith$elm_ui$Element$row,
-				_List_fromArray(
-					[$mdgriffith$elm_ui$Element$centerX]),
+				$mdgriffith$elm_ui$Element$column,
 				_List_fromArray(
 					[
+						$mdgriffith$elm_ui$Element$width(
+						$mdgriffith$elm_ui$Element$fillPortion(1)),
+						$mdgriffith$elm_ui$Element$spacing(10),
+						$mdgriffith$elm_ui$Element$padding(10),
+						$mdgriffith$elm_ui$Element$alignTop
+					]),
+				A2(
+					$elm$core$List$map,
+					$author$project$Pages$TaskList$taskCard(
 						A2(
-						$mdgriffith$elm_ui$Element$column,
-						_List_fromArray(
-							[
-								$mdgriffith$elm_ui$Element$width(
-								$mdgriffith$elm_ui$Element$fillPortion(1)),
-								$mdgriffith$elm_ui$Element$spacing(10),
-								$mdgriffith$elm_ui$Element$padding(10),
-								$mdgriffith$elm_ui$Element$alignTop
-							]),
-						A2(
-							$elm$core$List$map,
-							$author$project$Main$taskCard(
-								A2(
-									$elm$core$Maybe$map,
-									function ($) {
-										return $.id;
-									},
-									model.selectedTask)),
-							model.granaryTasks)),
-						A2(
-						$mdgriffith$elm_ui$Element$column,
-						_List_fromArray(
-							[
-								$mdgriffith$elm_ui$Element$width(
-								$mdgriffith$elm_ui$Element$fillPortion(3)),
-								$mdgriffith$elm_ui$Element$height($mdgriffith$elm_ui$Element$fill),
-								$mdgriffith$elm_ui$Element$spacing(10),
-								$mdgriffith$elm_ui$Element$padding(10)
-							]),
-						A2(
-							$elm$core$Maybe$withDefault,
-							_List_fromArray(
-								[
-									A2($author$project$Main$styledPrimaryText, _List_Nil, '👈 Choose a task on the left')
-								]),
-							A2(
-								$elm$core$Maybe$map,
-								function (selected) {
-									return _Utils_ap(
-										A3($author$project$Main$executionInput, model.formValues, model.taskValidationErrors, selected),
+							$elm$core$Maybe$map,
+							function ($) {
+								return $.id;
+							},
+							model.selectedTask)),
+					model.tasks)),
+				A2(
+				$mdgriffith$elm_ui$Element$column,
+				_List_fromArray(
+					[
+						$mdgriffith$elm_ui$Element$width(
+						$mdgriffith$elm_ui$Element$fillPortion(3)),
+						$mdgriffith$elm_ui$Element$height($mdgriffith$elm_ui$Element$fill),
+						$mdgriffith$elm_ui$Element$spacing(10),
+						$mdgriffith$elm_ui$Element$padding(10)
+					]),
+				A2(
+					$elm$core$Maybe$withDefault,
+					_List_fromArray(
+						[
+							A2($author$project$Styled$styledPrimaryText, _List_Nil, '👈 Choose a task on the left')
+						]),
+					A2(
+						$elm$core$Maybe$map,
+						function (selected) {
+							return _Utils_ap(
+								A3($author$project$Pages$TaskList$executionInput, model.formValues, model.taskValidationErrors, selected),
+								_List_fromArray(
+									[
+										A2(
+										$mdgriffith$elm_ui$Element$row,
+										_List_Nil,
 										_List_fromArray(
 											[
-												A2(
-												$mdgriffith$elm_ui$Element$row,
-												_List_Nil,
-												_List_fromArray(
-													[
-														A4(
-														$author$project$Main$submitButton,
-														$author$project$Main$allowTaskSubmit(model.activeSchema),
-														model.formValues,
-														'Some inputs are invalid',
-														$author$project$Main$CreateExecution(
-															A3($author$project$Main$toExecutionCreate, selected.name, selected.id, model.formValues)))
-													]))
-											]));
-								},
-								model.selectedTask)))
-					]))
+												A4(
+												$author$project$Styled$submitButton,
+												$author$project$Pages$TaskList$allowTaskSubmit(model.activeSchema),
+												model.formValues,
+												'Some inputs are invalid',
+												$author$project$Types$CreateExecution(
+													A3($author$project$Pages$TaskList$toExecutionCreate, selected.name, selected.id, model.formValues)))
+											]))
+									]));
+						},
+						model.selectedTask)))
 			]));
 };
 var $author$project$Main$view = function (model) {
-	var _v0 = _Utils_Tuple2(model.route, model.secrets);
+	var _v0 = _Utils_Tuple3(
+		model.route,
+		model.secrets,
+		_Utils_Tuple2(model.taskListModel, model.executionListModel));
 	_v0$2:
 	while (true) {
 		if (_v0.b.$ === 'Just') {
 			switch (_v0.a.$) {
 				case 'TaskList':
-					var _v1 = _v0.a;
-					var taskListBody = $author$project$Main$taskList(model);
-					return {
-						body: _List_fromArray(
-							[
-								A2($mdgriffith$elm_ui$Element$layout, _List_Nil, taskListBody)
-							]),
-						title: 'Available Models'
-					};
+					if (_v0.c.a.$ === 'Just') {
+						var _v1 = _v0.a;
+						var _v2 = _v0.c;
+						var tlm = _v2.a.a;
+						var taskListBody = $author$project$Pages$TaskList$taskList(tlm);
+						return {
+							body: _List_fromArray(
+								[
+									A2(
+									$mdgriffith$elm_ui$Element$layout,
+									_List_Nil,
+									$author$project$Main$logoTop(
+										_List_fromArray(
+											[taskListBody])))
+								]),
+							title: 'Available Tasks'
+						};
+					} else {
+						break _v0$2;
+					}
 				case 'ExecutionList':
-					return {
-						body: _List_fromArray(
-							[
-								A2(
-								$mdgriffith$elm_ui$Element$layout,
-								_List_Nil,
-								$author$project$Main$executionList(model))
-							]),
-						title: 'Execution list'
-					};
+					if (_v0.c.b.$ === 'Just') {
+						var _v3 = _v0.c;
+						var elm = _v3.b.a;
+						return {
+							body: _List_fromArray(
+								[
+									A2(
+									$mdgriffith$elm_ui$Element$layout,
+									_List_Nil,
+									$author$project$Main$logoTop(
+										_List_fromArray(
+											[
+												$author$project$Pages$ExecutionList$executionList(elm)
+											])))
+								]),
+							title: 'Execution list'
+						};
+					} else {
+						break _v0$2;
+					}
 				default:
 					break _v0$2;
 			}
@@ -19282,8 +19387,8 @@ var $author$project$Main$view = function (model) {
 var $author$project$Main$main = $elm$browser$Browser$application(
 	{
 		init: $author$project$Main$init,
-		onUrlChange: $author$project$Main$UrlChanged,
-		onUrlRequest: $author$project$Main$Navigation,
+		onUrlChange: $author$project$Types$UrlChanged,
+		onUrlRequest: $author$project$Types$Navigation,
 		subscriptions: $elm$core$Basics$always($elm$core$Platform$Sub$none),
 		update: $author$project$Main$update,
 		view: $author$project$Main$view

--- a/api/src/main/resources/assets/index.html
+++ b/api/src/main/resources/assets/index.html
@@ -11505,7 +11505,7 @@ var $author$project$Main$update = F2(
 						model,
 						$elm$browser$Browser$Navigation$load(href));
 				}
-			case 'TaskSelect':
+			case 'NewExecutionForTask':
 				var task = msg.a;
 				var newRoute = A2(
 					$elm$core$Maybe$withDefault,
@@ -17267,6 +17267,12 @@ var $mdgriffith$elm_ui$Element$column = F2(
 						attrs))),
 			$mdgriffith$elm_ui$Internal$Model$Unkeyed(children));
 	});
+var $mdgriffith$elm_ui$Internal$Model$Class = F2(
+	function (a, b) {
+		return {$: 'Class', a: a, b: b};
+	});
+var $mdgriffith$elm_ui$Internal$Flag$fontWeight = $mdgriffith$elm_ui$Internal$Flag$flag(13);
+var $mdgriffith$elm_ui$Element$Font$bold = A2($mdgriffith$elm_ui$Internal$Model$Class, $mdgriffith$elm_ui$Internal$Flag$fontWeight, $mdgriffith$elm_ui$Internal$Style$classes.bold);
 var $author$project$Types$ToggleShowAssets = function (a) {
 	return {$: 'ToggleShowAssets', a: a};
 };
@@ -17348,10 +17354,6 @@ var $mdgriffith$elm_ui$Element$Input$onKey = F2(
 var $mdgriffith$elm_ui$Element$Input$onEnter = function (msg) {
 	return A2($mdgriffith$elm_ui$Element$Input$onKey, $mdgriffith$elm_ui$Element$Input$enter, msg);
 };
-var $mdgriffith$elm_ui$Internal$Model$Class = F2(
-	function (a, b) {
-		return {$: 'Class', a: a, b: b};
-	});
 var $mdgriffith$elm_ui$Internal$Flag$cursor = $mdgriffith$elm_ui$Internal$Flag$flag(21);
 var $mdgriffith$elm_ui$Element$pointer = A2($mdgriffith$elm_ui$Internal$Model$Class, $mdgriffith$elm_ui$Internal$Flag$cursor, $mdgriffith$elm_ui$Internal$Style$classes.cursorPointer);
 var $elm$html$Html$Attributes$tabindex = function (n) {
@@ -17412,6 +17414,10 @@ var $mdgriffith$elm_ui$Element$Input$button = F2(
 				_List_fromArray(
 					[label])));
 	});
+var $elm$html$Html$Attributes$download = function (fileName) {
+	return A2($elm$html$Html$Attributes$stringProperty, 'download', fileName);
+};
+var $mdgriffith$elm_ui$Element$htmlAttribute = $mdgriffith$elm_ui$Internal$Model$Attr;
 var $elm$html$Html$Attributes$href = function (url) {
 	return A2(
 		$elm$html$Html$Attributes$stringProperty,
@@ -17526,24 +17532,30 @@ var $author$project$Styled$styledPrimaryText = F2(
 			$mdgriffith$elm_ui$Element$text(s));
 	});
 var $mdgriffith$elm_ui$Element$Font$underline = $mdgriffith$elm_ui$Internal$Model$htmlClass($mdgriffith$elm_ui$Internal$Style$classes.underline);
-var $author$project$Pages$ExecutionList$executionAssetsList = $elm$core$List$map(
-	function (asset) {
-		return A2(
-			$mdgriffith$elm_ui$Element$link,
-			_List_Nil,
-			{
-				label: A2(
-					$author$project$Styled$styledPrimaryText,
-					_List_fromArray(
-						[$mdgriffith$elm_ui$Element$Font$underline]),
-					A2(
-						$elm$core$Maybe$withDefault,
-						$elm$core$String$concat(
-							A2($elm$core$List$intersperse, ', ', asset.roles)),
-						A2($elm_community$maybe_extra$Maybe$Extra$orElse, asset.description, asset.title))),
-				url: asset.href
-			});
-	});
+var $author$project$Pages$ExecutionList$executionAssetsList = function (execution) {
+	return $elm$core$List$map(
+		function (asset) {
+			return A2(
+				$mdgriffith$elm_ui$Element$link,
+				_List_fromArray(
+					[
+						$mdgriffith$elm_ui$Element$htmlAttribute(
+						$elm$html$Html$Attributes$download(execution.name))
+					]),
+				{
+					label: A2(
+						$author$project$Styled$styledPrimaryText,
+						_List_fromArray(
+							[$mdgriffith$elm_ui$Element$Font$underline]),
+						A2(
+							$elm$core$Maybe$withDefault,
+							$elm$core$String$concat(
+								A2($elm$core$List$intersperse, ', ', asset.roles)),
+							A2($elm_community$maybe_extra$Maybe$Extra$orElse, asset.description, asset.title))),
+					url: 'https://raw.githubusercontent.com/azavea/sentinel-2-stac-utils/master/data/short-product-info-l1c.csv'
+				});
+		});
+};
 var $mdgriffith$elm_ui$Internal$Model$AsRow = {$: 'AsRow'};
 var $mdgriffith$elm_ui$Internal$Model$asRow = $mdgriffith$elm_ui$Internal$Model$AsRow;
 var $mdgriffith$elm_ui$Element$row = F2(
@@ -17564,13 +17576,35 @@ var $mdgriffith$elm_ui$Element$row = F2(
 						attrs))),
 			$mdgriffith$elm_ui$Internal$Model$Unkeyed(children));
 	});
+var $mdgriffith$elm_ui$Internal$Model$SpacingStyle = F3(
+	function (a, b, c) {
+		return {$: 'SpacingStyle', a: a, b: b, c: c};
+	});
+var $mdgriffith$elm_ui$Internal$Flag$spacing = $mdgriffith$elm_ui$Internal$Flag$flag(3);
+var $mdgriffith$elm_ui$Internal$Model$spacingName = F2(
+	function (x, y) {
+		return 'spacing-' + ($elm$core$String$fromInt(x) + ('-' + $elm$core$String$fromInt(y)));
+	});
+var $mdgriffith$elm_ui$Element$spacing = function (x) {
+	return A2(
+		$mdgriffith$elm_ui$Internal$Model$StyleClass,
+		$mdgriffith$elm_ui$Internal$Flag$spacing,
+		A3(
+			$mdgriffith$elm_ui$Internal$Model$SpacingStyle,
+			A2($mdgriffith$elm_ui$Internal$Model$spacingName, x, x),
+			x,
+			x));
+};
 var $author$project$Pages$ExecutionList$executionAssets = F2(
 	function (showAssets, execution) {
 		return $elm$core$List$isEmpty(execution.results) ? _List_Nil : A2(
 			$elm$core$List$cons,
 			A2(
 				$mdgriffith$elm_ui$Element$row,
-				_List_Nil,
+				_List_fromArray(
+					[
+						$mdgriffith$elm_ui$Element$spacing(3)
+					]),
 				_List_fromArray(
 					[
 						A2(
@@ -17583,7 +17617,7 @@ var $author$project$Pages$ExecutionList$executionAssets = F2(
 						}),
 						A2($author$project$Styled$styledPrimaryText, _List_Nil, ' Show assets')
 					])),
-			showAssets ? $author$project$Pages$ExecutionList$executionAssetsList(execution.results) : _List_Nil);
+			showAssets ? A2($author$project$Pages$ExecutionList$executionAssetsList, execution, execution.results) : _List_Nil);
 	});
 var $mdgriffith$elm_ui$Internal$Model$Fill = function (a) {
 	return {$: 'Fill', a: a};
@@ -17761,35 +17795,16 @@ var $Orasund$elm_ui_framework$Framework$Card$simple = _Utils_ap(
 				$mdgriffith$elm_ui$Element$padding(20),
 				$mdgriffith$elm_ui$Element$height($mdgriffith$elm_ui$Element$shrink)
 			])));
-var $mdgriffith$elm_ui$Internal$Model$SpacingStyle = F3(
-	function (a, b, c) {
-		return {$: 'SpacingStyle', a: a, b: b, c: c};
-	});
-var $mdgriffith$elm_ui$Internal$Flag$spacing = $mdgriffith$elm_ui$Internal$Flag$flag(3);
-var $mdgriffith$elm_ui$Internal$Model$spacingName = F2(
-	function (x, y) {
-		return 'spacing-' + ($elm$core$String$fromInt(x) + ('-' + $elm$core$String$fromInt(y)));
-	});
-var $mdgriffith$elm_ui$Element$spacing = function (x) {
-	return A2(
-		$mdgriffith$elm_ui$Internal$Model$StyleClass,
-		$mdgriffith$elm_ui$Internal$Flag$spacing,
-		A3(
-			$mdgriffith$elm_ui$Internal$Model$SpacingStyle,
-			A2($mdgriffith$elm_ui$Internal$Model$spacingName, x, x),
-			x,
-			x));
-};
 var $author$project$Pages$ExecutionList$toEmoji = function (execution) {
 	var _v0 = _Utils_Tuple2(execution.statusReason, execution.results);
 	if (_v0.a.$ === 'Just') {
-		return '❌';
+		return '❌ Failed';
 	} else {
 		if (_v0.b.b) {
 			var _v1 = _v0.b;
-			return '✅';
+			return '✅ Succeeded';
 		} else {
-			return '🏃\u200D♀️';
+			return '🏃\u200D♀️ Running';
 		}
 	}
 };
@@ -17824,7 +17839,11 @@ var $author$project$Pages$ExecutionList$executionCard = F2(
 								_List_Nil,
 								_List_fromArray(
 									[
-										A2($author$project$Styled$styledPrimaryText, _List_Nil, execution.name)
+										A2(
+										$author$project$Styled$styledPrimaryText,
+										_List_fromArray(
+											[$mdgriffith$elm_ui$Element$Font$bold]),
+										execution.name)
 									])),
 								A2(
 								$mdgriffith$elm_ui$Element$row,
@@ -18272,7 +18291,6 @@ var $mdgriffith$elm_ui$Element$paddingEach = function (_v0) {
 			bottom,
 			left));
 };
-var $mdgriffith$elm_ui$Element$htmlAttribute = $mdgriffith$elm_ui$Internal$Model$Attr;
 var $mdgriffith$elm_ui$Element$Input$isFill = function (len) {
 	isFill:
 	while (true) {
@@ -18872,7 +18890,7 @@ var $author$project$Pages$ExecutionList$nameSearchInput = function (currValue) {
 					]),
 				$author$project$Types$SearchExecutionName,
 				currValue,
-				'Name like',
+				'Search',
 				'Search')));
 };
 var $author$project$Pages$ExecutionList$executionList = function (model) {
@@ -19295,7 +19313,14 @@ var $author$project$Styled$submitButton = F3(
 										allowSubmit ? 'pointer' : 'not-allowed'))
 								])),
 						{
-							label: A2($author$project$Styled$styledPrimaryText, _List_Nil, 'Submit'),
+							label: A2(
+								$mdgriffith$elm_ui$Element$el,
+								_List_fromArray(
+									[
+										allowSubmit ? $mdgriffith$elm_ui$Element$Font$color($author$project$Styled$primary) : $mdgriffith$elm_ui$Element$Font$color(
+										A3($mdgriffith$elm_ui$Element$rgb255, 168, 168, 168))
+									]),
+								$mdgriffith$elm_ui$Element$text('Submit')),
 							onPress: allowSubmit ? $elm$core$Maybe$Just(msg) : $elm$core$Maybe$Nothing
 						}))));
 	});
@@ -19304,7 +19329,7 @@ var $author$project$Main$loginPage = function (model) {
 		$mdgriffith$elm_ui$Element$column,
 		_List_fromArray(
 			[
-				$mdgriffith$elm_ui$Element$spacing(3),
+				$mdgriffith$elm_ui$Element$spacing(24),
 				$mdgriffith$elm_ui$Element$centerX,
 				$mdgriffith$elm_ui$Element$centerY,
 				$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$shrink)
@@ -19325,20 +19350,12 @@ var $author$project$Main$loginPage = function (model) {
 				$mdgriffith$elm_ui$Element$row,
 				_List_fromArray(
 					[
-						$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill)
+						$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill),
+						$mdgriffith$elm_ui$Element$spacing(8)
 					]),
 				_List_fromArray(
 					[
-						A5($author$project$Styled$textInput, _List_Nil, $author$project$Types$TokenInput, model.secretsUnsubmitted, 'Enter a token', 'Token input')
-					])),
-				A2(
-				$mdgriffith$elm_ui$Element$row,
-				_List_fromArray(
-					[
-						$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill)
-					]),
-				_List_fromArray(
-					[
+						A5($author$project$Styled$textInput, _List_Nil, $author$project$Types$TokenInput, model.secretsUnsubmitted, 'Enter a token', 'Token input'),
 						A3(
 						$author$project$Styled$submitButton,
 						A2($elm$core$Basics$composeL, $elm$core$Basics$not, $elm$core$String$isEmpty),
@@ -20088,9 +20105,14 @@ var $author$project$Pages$TaskList$executionInput = F4(
 				A4($author$project$Pages$TaskList$schemaToForm, inputEvent, formValues.fromSchema, errors, subSchema));
 		}
 	});
-var $author$project$Types$TaskSelect = function (a) {
-	return {$: 'TaskSelect', a: a};
+var $elm$html$Html$h2 = _VirtualDom_node('h2');
+var $author$project$Types$NewExecutionForTask = function (a) {
+	return {$: 'NewExecutionForTask', a: a};
 };
+var $mdgriffith$elm_ui$Internal$Model$Left = {$: 'Left'};
+var $mdgriffith$elm_ui$Element$alignLeft = $mdgriffith$elm_ui$Internal$Model$AlignX($mdgriffith$elm_ui$Internal$Model$Left);
+var $mdgriffith$elm_ui$Internal$Model$Right = {$: 'Right'};
+var $mdgriffith$elm_ui$Element$alignRight = $mdgriffith$elm_ui$Internal$Model$AlignX($mdgriffith$elm_ui$Internal$Model$Right);
 var $author$project$Styled$styledSecondaryText = F2(
 	function (attrs, s) {
 		return A2(
@@ -20101,76 +20123,65 @@ var $author$project$Styled$styledSecondaryText = F2(
 				attrs),
 			$mdgriffith$elm_ui$Element$text(s));
 	});
-var $author$project$Pages$TaskList$tasksLink = F2(
-	function (selectedId, task) {
-		return _Utils_eq(
-			selectedId,
-			$elm$core$Maybe$Just(task.id)) ? A2(
-			$mdgriffith$elm_ui$Element$row,
-			_List_fromArray(
-				[
-					$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill)
-				]),
-			_List_fromArray(
-				[
-					A2(
-					$mdgriffith$elm_ui$Element$row,
-					_List_Nil,
-					_List_fromArray(
-						[
-							A2(
-							$mdgriffith$elm_ui$Element$link,
-							_List_Nil,
-							{
-								label: A2(
-									$author$project$Styled$styledSecondaryText,
-									_List_fromArray(
-										[$mdgriffith$elm_ui$Element$Font$underline]),
-									'Executions'),
-								url: A2(
-									$author$project$Urls$executionsUrl,
-									$elm$core$Maybe$Nothing,
-									$elm$core$Maybe$Just(task.id))
-							})
-						]))
-				])) : A2($mdgriffith$elm_ui$Element$row, _List_Nil, _List_Nil);
-	});
-var $author$project$Pages$TaskList$taskCard = F2(
-	function (selectedId, task) {
-		return A2(
-			$mdgriffith$elm_ui$Element$column,
+var $author$project$Pages$TaskList$tasksLink = function (task) {
+	return A2(
+		$mdgriffith$elm_ui$Element$link,
+		_List_Nil,
+		{
+			label: A2(
+				$author$project$Styled$styledSecondaryText,
+				_List_fromArray(
+					[$mdgriffith$elm_ui$Element$Font$underline]),
+				'Executions'),
+			url: A2(
+				$author$project$Urls$executionsUrl,
+				$elm$core$Maybe$Nothing,
+				$elm$core$Maybe$Just(task.id))
+		});
+};
+var $author$project$Pages$TaskList$taskCard = function (task) {
+	return A2(
+		$mdgriffith$elm_ui$Element$column,
+		A2(
+			$elm$core$List$cons,
+			$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill),
 			A2(
 				$elm$core$List$cons,
-				$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill),
+				$mdgriffith$elm_ui$Element$spacing(5),
+				A2($elm$core$List$cons, $mdgriffith$elm_ui$Element$centerY, $Orasund$elm_ui_framework$Framework$Button$simple))),
+		_List_fromArray(
+			[
 				A2(
-					$elm$core$List$cons,
-					$mdgriffith$elm_ui$Element$spacing(5),
-					A2($elm$core$List$cons, $mdgriffith$elm_ui$Element$centerY, $Orasund$elm_ui_framework$Framework$Button$simple))),
-			_List_fromArray(
-				[
-					A2(
-					$mdgriffith$elm_ui$Element$row,
-					A2(
-						$elm$core$List$cons,
-						$mdgriffith$elm_ui$Element$Font$color($author$project$Styled$primary),
-						_Utils_eq(
-							$elm$core$Maybe$Just(task.id),
-							selectedId) ? _List_fromArray(
-							[$author$project$Styled$secondaryShadow]) : _List_Nil),
-					_List_fromArray(
-						[
-							A2(
-							$mdgriffith$elm_ui$Element$Input$button,
-							_List_Nil,
-							{
-								label: $mdgriffith$elm_ui$Element$text(task.name),
-								onPress: $elm$core$Maybe$Just(
-									$author$project$Types$TaskSelect(task))
-							})
-						])),
-					A2($author$project$Pages$TaskList$tasksLink, selectedId, task)
-				]));
-	});
+				$mdgriffith$elm_ui$Element$row,
+				_List_fromArray(
+					[
+						$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill),
+						$mdgriffith$elm_ui$Element$spacing(3)
+					]),
+				_List_fromArray(
+					[
+						A2(
+						$author$project$Styled$styledPrimaryText,
+						_List_fromArray(
+							[$mdgriffith$elm_ui$Element$alignLeft]),
+						task.name),
+						A2(
+						$mdgriffith$elm_ui$Element$Input$button,
+						_List_fromArray(
+							[
+								$mdgriffith$elm_ui$Element$alignRight,
+								$mdgriffith$elm_ui$Element$htmlAttribute(
+								A2($elm$html$Html$Attributes$style, 'margin', '0 12px'))
+							]),
+						{
+							label: $mdgriffith$elm_ui$Element$text('➕'),
+							onPress: $elm$core$Maybe$Just(
+								$author$project$Types$NewExecutionForTask(task))
+						}),
+						$author$project$Pages$TaskList$tasksLink(task)
+					]))
+			]));
+};
 var $author$project$Pages$TaskList$ExecutionCreate = F3(
 	function (name, taskId, _arguments) {
 		return {_arguments: _arguments, name: name, taskId: taskId};
@@ -20204,6 +20215,14 @@ var $author$project$Pages$TaskList$taskList = function (model) {
 			[$mdgriffith$elm_ui$Element$centerX]),
 		_List_fromArray(
 			[
+				$mdgriffith$elm_ui$Element$html(
+				A2(
+					$elm$html$Html$h2,
+					_List_Nil,
+					_List_fromArray(
+						[
+							$elm$html$Html$text('Tasks')
+						]))),
 				A2(
 				$mdgriffith$elm_ui$Element$column,
 				_List_fromArray(
@@ -20214,16 +20233,7 @@ var $author$project$Pages$TaskList$taskList = function (model) {
 						$mdgriffith$elm_ui$Element$padding(10),
 						$mdgriffith$elm_ui$Element$alignTop
 					]),
-				A2(
-					$elm$core$List$map,
-					$author$project$Pages$TaskList$taskCard(
-						A2(
-							$elm$core$Maybe$map,
-							function ($) {
-								return $.id;
-							},
-							model.selectedTask)),
-					model.tasks)),
+				A2($elm$core$List$map, $author$project$Pages$TaskList$taskCard, model.tasks)),
 				A2(
 				$mdgriffith$elm_ui$Element$column,
 				_List_fromArray(
@@ -20289,7 +20299,11 @@ var $author$project$Main$view = function (model) {
 							[
 								A2(
 								$mdgriffith$elm_ui$Element$layout,
-								_List_Nil,
+								_List_fromArray(
+									[
+										$mdgriffith$elm_ui$Element$width(
+										A2($mdgriffith$elm_ui$Element$minimum, 1024, $mdgriffith$elm_ui$Element$fill))
+									]),
 								$author$project$Main$logoTop(
 									_List_fromArray(
 										[taskListBody])))
@@ -20303,7 +20317,11 @@ var $author$project$Main$view = function (model) {
 							[
 								A2(
 								$mdgriffith$elm_ui$Element$layout,
-								_List_Nil,
+								_List_fromArray(
+									[
+										$mdgriffith$elm_ui$Element$width(
+										A2($mdgriffith$elm_ui$Element$minimum, 1024, $mdgriffith$elm_ui$Element$fill))
+									]),
 								$author$project$Main$logoTop(
 									_List_fromArray(
 										[
@@ -20324,7 +20342,11 @@ var $author$project$Main$view = function (model) {
 			[
 				A2(
 				$mdgriffith$elm_ui$Element$layout,
-				_List_Nil,
+				_List_fromArray(
+					[
+						$mdgriffith$elm_ui$Element$width(
+						A2($mdgriffith$elm_ui$Element$minimum, 1024, $mdgriffith$elm_ui$Element$fill))
+					]),
 				$author$project$Main$loginPage(model))
 			]),
 		title: 'Granary Model Dashboard'

--- a/api/src/main/resources/assets/index.html
+++ b/api/src/main/resources/assets/index.html
@@ -11804,7 +11804,9 @@ var $author$project$Main$update = F2(
 				return _Utils_Tuple2(
 					_Utils_update(
 						model,
-						{route: $author$project$Main$Login}),
+						{
+							route: $author$project$Main$TaskList($author$project$Pages$TaskList$emptyTaskListModel)
+						}),
 					A2($elm$browser$Browser$Navigation$pushUrl, model.key, '/tasks'));
 			case 'NameExecution':
 				var s = msg.a;
@@ -11858,6 +11860,7 @@ var $author$project$Main$update = F2(
 					if (_v8.b.$ === 'TaskList') {
 						var taskGrid = _v8.a.a;
 						var tlm = _v8.b.a;
+						var newTaskValidationErrors = A2($elm$core$Dict$remove, 'TASK_GRID', tlm.taskValidationErrors);
 						var formValues = tlm.formValues;
 						var addition = A2(
 							$elm$core$Dict$singleton,
@@ -11871,7 +11874,7 @@ var $author$project$Main$update = F2(
 							});
 						var updated = _Utils_update(
 							tlm,
-							{formValues: newFormValues});
+							{formValues: newFormValues, taskValidationErrors: newTaskValidationErrors});
 						return _Utils_Tuple2(
 							_Utils_update(
 								model,
@@ -19581,10 +19584,14 @@ var $author$project$Pages$TaskList$makeHelpfulErrorMessage = function (err) {
 			[
 				A2(
 				$mdgriffith$elm_ui$Element$row,
-				_List_Nil,
 				_List_fromArray(
 					[
-						$mdgriffith$elm_ui$Element$text('Structure of JSON in this field was unexpected')
+						$mdgriffith$elm_ui$Element$width(
+						A2($mdgriffith$elm_ui$Element$minimum, 300, $mdgriffith$elm_ui$Element$fill))
+					]),
+				_List_fromArray(
+					[
+						$mdgriffith$elm_ui$Element$text('Unexpected JSON structure')
 					]))
 			]);
 	}
@@ -20224,6 +20231,7 @@ var $author$project$Pages$TaskList$taskList = function (model) {
 						$mdgriffith$elm_ui$Element$width(
 						$mdgriffith$elm_ui$Element$fillPortion(3)),
 						$mdgriffith$elm_ui$Element$height($mdgriffith$elm_ui$Element$fill),
+						$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill),
 						$mdgriffith$elm_ui$Element$spacing(10),
 						$mdgriffith$elm_ui$Element$padding(10)
 					]),
@@ -20231,7 +20239,13 @@ var $author$project$Pages$TaskList$taskList = function (model) {
 					$elm$core$Maybe$withDefault,
 					_List_fromArray(
 						[
-							A2($author$project$Styled$styledPrimaryText, _List_Nil, '👈 Choose a task on the left')
+							A2(
+							$author$project$Styled$styledPrimaryText,
+							_List_fromArray(
+								[
+									$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill)
+								]),
+							'👈 Choose a task on the left')
 						]),
 					A2(
 						$elm$core$Maybe$map,
@@ -20242,7 +20256,11 @@ var $author$project$Pages$TaskList$taskList = function (model) {
 									[
 										A2(
 										$mdgriffith$elm_ui$Element$row,
-										_List_Nil,
+										_List_fromArray(
+											[
+												$mdgriffith$elm_ui$Element$width(
+												A2($mdgriffith$elm_ui$Element$maximum, 300, $mdgriffith$elm_ui$Element$fill))
+											]),
 										_List_fromArray(
 											[
 												A3(

--- a/api/src/main/resources/assets/index.html
+++ b/api/src/main/resources/assets/index.html
@@ -17552,7 +17552,7 @@ var $author$project$Pages$ExecutionList$executionAssetsList = function (executio
 							$elm$core$String$concat(
 								A2($elm$core$List$intersperse, ', ', asset.roles)),
 							A2($elm_community$maybe_extra$Maybe$Extra$orElse, asset.description, asset.title))),
-					url: 'https://raw.githubusercontent.com/azavea/sentinel-2-stac-utils/master/data/short-product-info-l1c.csv'
+					url: asset.href
 				});
 		});
 };
@@ -18862,7 +18862,10 @@ var $author$project$Styled$textInput = F5(
 				$mdgriffith$elm_ui$Element$focused(
 					_List_fromArray(
 						[$author$project$Styled$secondaryShadow])),
-				attrs),
+				A2(
+					$elm$core$List$cons,
+					$mdgriffith$elm_ui$Element$spacing(3),
+					attrs)),
 			{
 				label: $mdgriffith$elm_ui$Element$Input$labelHidden(label),
 				onChange: f,
@@ -19553,7 +19556,10 @@ var $author$project$Pages$TaskList$makeErr = function (err) {
 				function (s) {
 					return A2(
 						$mdgriffith$elm_ui$Element$row,
-						_List_Nil,
+						_List_fromArray(
+							[
+								$mdgriffith$elm_ui$Element$spacing(3)
+							]),
 						_List_fromArray(
 							[
 								$mdgriffith$elm_ui$Element$text('Missing field: '),
@@ -19570,7 +19576,10 @@ var $author$project$Pages$TaskList$makeErr = function (err) {
 				[
 					A2(
 					$mdgriffith$elm_ui$Element$row,
-					_List_Nil,
+					_List_fromArray(
+						[
+							$mdgriffith$elm_ui$Element$spacing(3)
+						]),
 					_List_fromArray(
 						[
 							$mdgriffith$elm_ui$Element$text('Invalid json')
@@ -19580,15 +19589,31 @@ var $author$project$Pages$TaskList$makeErr = function (err) {
 			var t = _v0.a;
 			return _List_fromArray(
 				[
-					$mdgriffith$elm_ui$Element$text(t)
+					A2(
+					$mdgriffith$elm_ui$Element$row,
+					_List_fromArray(
+						[
+							$mdgriffith$elm_ui$Element$spacing(3)
+						]),
+					_List_fromArray(
+						[
+							$mdgriffith$elm_ui$Element$text(t)
+						]))
 				]);
 		case 'RequiredProperty':
 			return _List_Nil;
 		default:
 			return _List_fromArray(
 				[
-					$mdgriffith$elm_ui$Element$text(
-					'I can\'t tell what else is wrong with ' + $author$project$Pages$TaskList$getErrField(err))
+					A2(
+					$mdgriffith$elm_ui$Element$row,
+					_List_fromArray(
+						[
+							$mdgriffith$elm_ui$Element$spacing(3)
+						]),
+					$elm$core$List$singleton(
+						$mdgriffith$elm_ui$Element$text(
+							'I can\'t tell what else is wrong with ' + $author$project$Pages$TaskList$getErrField(err))))
 				]);
 	}
 };
@@ -19604,7 +19629,8 @@ var $author$project$Pages$TaskList$makeHelpfulErrorMessage = function (err) {
 				_List_fromArray(
 					[
 						$mdgriffith$elm_ui$Element$width(
-						A2($mdgriffith$elm_ui$Element$minimum, 300, $mdgriffith$elm_ui$Element$fill))
+						A2($mdgriffith$elm_ui$Element$minimum, 300, $mdgriffith$elm_ui$Element$fill)),
+						$mdgriffith$elm_ui$Element$spacing(3)
 					]),
 				_List_fromArray(
 					[
@@ -20035,24 +20061,14 @@ var $author$project$Pages$TaskList$schemaToForm = F4(
 					$mdgriffith$elm_ui$Element$column,
 					_List_fromArray(
 						[
-							$mdgriffith$elm_ui$Element$spacing(10)
+							$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill)
 						]),
-					_List_fromArray(
-						[
-							A2(
-							$mdgriffith$elm_ui$Element$row,
-							_List_Nil,
-							_List_fromArray(
-								[
-									toInput(
-									_Utils_Tuple2(k, subSchema))
-								])),
-							A2(
-							$mdgriffith$elm_ui$Element$row,
-							_List_Nil,
-							errs(
-								_Utils_Tuple2(k, subSchema)))
-						]));
+					A2(
+						$elm$core$List$cons,
+						toInput(
+							_Utils_Tuple2(k, subSchema)),
+						errs(
+							_Utils_Tuple2(k, subSchema))));
 			} else {
 				return A2(
 					$mdgriffith$elm_ui$Element$row,
@@ -20210,79 +20226,89 @@ var $author$project$Pages$TaskList$toExecutionCreate = F3(
 	});
 var $author$project$Pages$TaskList$taskList = function (model) {
 	return A2(
-		$mdgriffith$elm_ui$Element$row,
+		$mdgriffith$elm_ui$Element$column,
 		_List_fromArray(
 			[$mdgriffith$elm_ui$Element$centerX]),
 		_List_fromArray(
 			[
-				$mdgriffith$elm_ui$Element$html(
 				A2(
-					$elm$html$Html$h2,
-					_List_Nil,
-					_List_fromArray(
-						[
-							$elm$html$Html$text('Tasks')
-						]))),
-				A2(
-				$mdgriffith$elm_ui$Element$column,
+				$mdgriffith$elm_ui$Element$row,
 				_List_fromArray(
 					[
-						$mdgriffith$elm_ui$Element$width(
-						$mdgriffith$elm_ui$Element$fillPortion(1)),
-						$mdgriffith$elm_ui$Element$spacing(10),
-						$mdgriffith$elm_ui$Element$padding(10),
-						$mdgriffith$elm_ui$Element$alignTop
+						$mdgriffith$elm_ui$Element$centerX,
+						$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill)
 					]),
-				A2($elm$core$List$map, $author$project$Pages$TaskList$taskCard, model.tasks)),
-				A2(
-				$mdgriffith$elm_ui$Element$column,
 				_List_fromArray(
 					[
-						$mdgriffith$elm_ui$Element$width(
-						$mdgriffith$elm_ui$Element$fillPortion(3)),
-						$mdgriffith$elm_ui$Element$height($mdgriffith$elm_ui$Element$fill),
-						$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill),
-						$mdgriffith$elm_ui$Element$spacing(10),
-						$mdgriffith$elm_ui$Element$padding(10)
-					]),
-				A2(
-					$elm$core$Maybe$withDefault,
-					_List_fromArray(
-						[
-							A2(
-							$author$project$Styled$styledPrimaryText,
+						$mdgriffith$elm_ui$Element$html(
+						A2(
+							$elm$html$Html$h2,
+							_List_Nil,
 							_List_fromArray(
 								[
-									$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill)
-								]),
-							'👈 Choose a task on the left')
-						]),
-					A2(
-						$elm$core$Maybe$map,
-						function (selected) {
-							return _Utils_ap(
-								A4($author$project$Pages$TaskList$executionInput, model.inputState, model.formValues, model.taskValidationErrors, selected),
-								_List_fromArray(
-									[
-										A2(
-										$mdgriffith$elm_ui$Element$row,
+									$elm$html$Html$text('Tasks')
+								])))
+					])),
+				A2(
+				$mdgriffith$elm_ui$Element$row,
+				_List_fromArray(
+					[
+						$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill)
+					]),
+				_List_fromArray(
+					[
+						A2(
+						$mdgriffith$elm_ui$Element$column,
+						_List_fromArray(
+							[
+								$mdgriffith$elm_ui$Element$width(
+								$mdgriffith$elm_ui$Element$fillPortion(1)),
+								$mdgriffith$elm_ui$Element$spacing(10),
+								$mdgriffith$elm_ui$Element$padding(10),
+								$mdgriffith$elm_ui$Element$alignTop
+							]),
+						A2($elm$core$List$map, $author$project$Pages$TaskList$taskCard, model.tasks)),
+						A2(
+						$mdgriffith$elm_ui$Element$column,
+						_List_fromArray(
+							[
+								$mdgriffith$elm_ui$Element$width(
+								$mdgriffith$elm_ui$Element$fillPortion(3)),
+								$mdgriffith$elm_ui$Element$height($mdgriffith$elm_ui$Element$fill),
+								$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill),
+								$mdgriffith$elm_ui$Element$spacing(10),
+								$mdgriffith$elm_ui$Element$padding(10)
+							]),
+						A2(
+							$elm$core$Maybe$withDefault,
+							_List_Nil,
+							A2(
+								$elm$core$Maybe$map,
+								function (selected) {
+									return _Utils_ap(
+										A4($author$project$Pages$TaskList$executionInput, model.inputState, model.formValues, model.taskValidationErrors, selected),
 										_List_fromArray(
 											[
-												$mdgriffith$elm_ui$Element$width(
-												A2($mdgriffith$elm_ui$Element$maximum, 300, $mdgriffith$elm_ui$Element$fill))
-											]),
-										_List_fromArray(
-											[
-												A3(
-												$author$project$Styled$submitButton,
-												$author$project$Pages$TaskList$allowTaskSubmit(model.activeSchema),
-												model.formValues,
-												$author$project$Types$CreateExecution(
-													A3($author$project$Pages$TaskList$toExecutionCreate, selected.name, selected.id, model.formValues)))
-											]))
-									]));
-						},
-						model.selectedTask)))
+												A2(
+												$mdgriffith$elm_ui$Element$row,
+												_List_fromArray(
+													[
+														$mdgriffith$elm_ui$Element$width(
+														A2($mdgriffith$elm_ui$Element$maximum, 300, $mdgriffith$elm_ui$Element$fill))
+													]),
+												_List_fromArray(
+													[
+														A3(
+														$author$project$Styled$submitButton,
+														$author$project$Pages$TaskList$allowTaskSubmit(model.activeSchema),
+														model.formValues,
+														$author$project$Types$CreateExecution(
+															A3($author$project$Pages$TaskList$toExecutionCreate, selected.name, selected.id, model.formValues)))
+													]))
+											]));
+								},
+								model.selectedTask)))
+					]))
 			]));
 };
 var $author$project$Main$view = function (model) {

--- a/api/src/main/resources/assets/index.html
+++ b/api/src/main/resources/assets/index.html
@@ -11556,11 +11556,16 @@ var $author$project$Main$update = F2(
 				if (msg.b.$ === 'Ok') {
 					var taskId = msg.a;
 					var executionsPage = msg.b.a;
-					var withExecutions = function (elm) {
+					var executionListModelUpdate = function (elm) {
 						return _Utils_update(
 							elm,
 							{executions: executionsPage.results, forTask: taskId});
-					}($author$project$Pages$ExecutionList$emptyExecutionListModel);
+					};
+					var freshExecutionListModel = executionListModelUpdate($author$project$Pages$ExecutionList$emptyExecutionListModel);
+					var withExecutions = A2(
+						$elm$core$Maybe$withDefault,
+						freshExecutionListModel,
+						A2($author$project$Main$updateExecutionListModel, executionListModelUpdate, model.route));
 					return _Utils_Tuple2(
 						_Utils_update(
 							model,

--- a/api/src/main/resources/assets/index.html
+++ b/api/src/main/resources/assets/index.html
@@ -17417,17 +17417,16 @@ var $mdgriffith$elm_ui$Element$Input$button = F2(
 var $elm$html$Html$Attributes$download = function (fileName) {
 	return A2($elm$html$Html$Attributes$stringProperty, 'download', fileName);
 };
-var $mdgriffith$elm_ui$Element$htmlAttribute = $mdgriffith$elm_ui$Internal$Model$Attr;
 var $elm$html$Html$Attributes$href = function (url) {
 	return A2(
 		$elm$html$Html$Attributes$stringProperty,
 		'href',
 		_VirtualDom_noJavaScriptUri(url));
 };
-var $elm$html$Html$Attributes$rel = _VirtualDom_attribute('rel');
-var $mdgriffith$elm_ui$Element$link = F2(
+var $mdgriffith$elm_ui$Element$downloadAs = F2(
 	function (attrs, _v0) {
 		var url = _v0.url;
+		var filename = _v0.filename;
 		var label = _v0.label;
 		return A4(
 			$mdgriffith$elm_ui$Internal$Model$element,
@@ -17440,7 +17439,7 @@ var $mdgriffith$elm_ui$Element$link = F2(
 				A2(
 					$elm$core$List$cons,
 					$mdgriffith$elm_ui$Internal$Model$Attr(
-						$elm$html$Html$Attributes$rel('noopener noreferrer')),
+						$elm$html$Html$Attributes$download(filename)),
 					A2(
 						$elm$core$List$cons,
 						$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$shrink),
@@ -17449,8 +17448,11 @@ var $mdgriffith$elm_ui$Element$link = F2(
 							$mdgriffith$elm_ui$Element$height($mdgriffith$elm_ui$Element$shrink),
 							A2(
 								$elm$core$List$cons,
-								$mdgriffith$elm_ui$Internal$Model$htmlClass($mdgriffith$elm_ui$Internal$Style$classes.contentCenterX + (' ' + ($mdgriffith$elm_ui$Internal$Style$classes.contentCenterY + (' ' + $mdgriffith$elm_ui$Internal$Style$classes.link)))),
-								attrs))))),
+								$mdgriffith$elm_ui$Internal$Model$htmlClass($mdgriffith$elm_ui$Internal$Style$classes.contentCenterX),
+								A2(
+									$elm$core$List$cons,
+									$mdgriffith$elm_ui$Internal$Model$htmlClass($mdgriffith$elm_ui$Internal$Style$classes.contentCenterY),
+									attrs)))))),
 			$mdgriffith$elm_ui$Internal$Model$Unkeyed(
 				_List_fromArray(
 					[label])));
@@ -17533,25 +17535,25 @@ var $author$project$Styled$styledPrimaryText = F2(
 	});
 var $mdgriffith$elm_ui$Element$Font$underline = $mdgriffith$elm_ui$Internal$Model$htmlClass($mdgriffith$elm_ui$Internal$Style$classes.underline);
 var $author$project$Pages$ExecutionList$executionAssetsList = function (execution) {
+	var assetName = function (asset) {
+		return A2(
+			$elm$core$Maybe$withDefault,
+			$elm$core$String$concat(
+				A2($elm$core$List$intersperse, ', ', asset.roles)),
+			A2($elm_community$maybe_extra$Maybe$Extra$orElse, asset.description, asset.title));
+	};
 	return $elm$core$List$map(
 		function (asset) {
 			return A2(
-				$mdgriffith$elm_ui$Element$link,
-				_List_fromArray(
-					[
-						$mdgriffith$elm_ui$Element$htmlAttribute(
-						$elm$html$Html$Attributes$download(execution.name))
-					]),
+				$mdgriffith$elm_ui$Element$downloadAs,
+				_List_Nil,
 				{
+					filename: execution.name,
 					label: A2(
 						$author$project$Styled$styledPrimaryText,
 						_List_fromArray(
 							[$mdgriffith$elm_ui$Element$Font$underline]),
-						A2(
-							$elm$core$Maybe$withDefault,
-							$elm$core$String$concat(
-								A2($elm$core$List$intersperse, ', ', asset.roles)),
-							A2($elm_community$maybe_extra$Maybe$Extra$orElse, asset.description, asset.title))),
+						assetName(asset)),
 					url: asset.href
 				});
 		});
@@ -18291,6 +18293,7 @@ var $mdgriffith$elm_ui$Element$paddingEach = function (_v0) {
 			bottom,
 			left));
 };
+var $mdgriffith$elm_ui$Element$htmlAttribute = $mdgriffith$elm_ui$Internal$Model$Attr;
 var $mdgriffith$elm_ui$Element$Input$isFill = function (len) {
 	isFill:
 	while (true) {
@@ -20065,12 +20068,48 @@ var $author$project$Pages$TaskList$executionInput = F4(
 				A4($author$project$Pages$TaskList$schemaToForm, inputEvent, formValues.fromSchema, errors, subSchema));
 		}
 	});
-var $elm$html$Html$h2 = _VirtualDom_node('h2');
+var $mdgriffith$elm_ui$Element$Font$size = function (i) {
+	return A2(
+		$mdgriffith$elm_ui$Internal$Model$StyleClass,
+		$mdgriffith$elm_ui$Internal$Flag$fontSize,
+		$mdgriffith$elm_ui$Internal$Model$FontSize(i));
+};
 var $author$project$Types$NewExecutionForTask = function (a) {
 	return {$: 'NewExecutionForTask', a: a};
 };
 var $mdgriffith$elm_ui$Internal$Model$Left = {$: 'Left'};
 var $mdgriffith$elm_ui$Element$alignLeft = $mdgriffith$elm_ui$Internal$Model$AlignX($mdgriffith$elm_ui$Internal$Model$Left);
+var $elm$html$Html$Attributes$rel = _VirtualDom_attribute('rel');
+var $mdgriffith$elm_ui$Element$link = F2(
+	function (attrs, _v0) {
+		var url = _v0.url;
+		var label = _v0.label;
+		return A4(
+			$mdgriffith$elm_ui$Internal$Model$element,
+			$mdgriffith$elm_ui$Internal$Model$asEl,
+			$mdgriffith$elm_ui$Internal$Model$NodeName('a'),
+			A2(
+				$elm$core$List$cons,
+				$mdgriffith$elm_ui$Internal$Model$Attr(
+					$elm$html$Html$Attributes$href(url)),
+				A2(
+					$elm$core$List$cons,
+					$mdgriffith$elm_ui$Internal$Model$Attr(
+						$elm$html$Html$Attributes$rel('noopener noreferrer')),
+					A2(
+						$elm$core$List$cons,
+						$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$shrink),
+						A2(
+							$elm$core$List$cons,
+							$mdgriffith$elm_ui$Element$height($mdgriffith$elm_ui$Element$shrink),
+							A2(
+								$elm$core$List$cons,
+								$mdgriffith$elm_ui$Internal$Model$htmlClass($mdgriffith$elm_ui$Internal$Style$classes.contentCenterX + (' ' + ($mdgriffith$elm_ui$Internal$Style$classes.contentCenterY + (' ' + $mdgriffith$elm_ui$Internal$Style$classes.link)))),
+								attrs))))),
+			$mdgriffith$elm_ui$Internal$Model$Unkeyed(
+				_List_fromArray(
+					[label])));
+	});
 var $author$project$Styled$styledSecondaryText = F2(
 	function (attrs, s) {
 		return A2(
@@ -20170,26 +20209,28 @@ var $author$project$Pages$TaskList$taskList = function (model) {
 	return A2(
 		$mdgriffith$elm_ui$Element$column,
 		_List_fromArray(
-			[$mdgriffith$elm_ui$Element$centerX]),
+			[
+				$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill)
+			]),
 		_List_fromArray(
 			[
 				A2(
 				$mdgriffith$elm_ui$Element$row,
 				_List_fromArray(
 					[
-						$mdgriffith$elm_ui$Element$centerX,
 						$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill)
 					]),
 				_List_fromArray(
 					[
-						$mdgriffith$elm_ui$Element$html(
 						A2(
-							$elm$html$Html$h2,
-							_List_Nil,
-							_List_fromArray(
-								[
-									$elm$html$Html$text('Tasks')
-								])))
+						$author$project$Styled$styledPrimaryText,
+						_List_fromArray(
+							[
+								$mdgriffith$elm_ui$Element$Font$bold,
+								$mdgriffith$elm_ui$Element$Font$size(24),
+								$mdgriffith$elm_ui$Element$centerX
+							]),
+						'Tasks')
 					])),
 				A2(
 				$mdgriffith$elm_ui$Element$row,
@@ -20197,9 +20238,9 @@ var $author$project$Pages$TaskList$taskList = function (model) {
 					[
 						$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill)
 					]),
-				_List_fromArray(
-					[
-						A2(
+				A2(
+					$elm$core$List$cons,
+					A2(
 						$mdgriffith$elm_ui$Element$column,
 						_List_fromArray(
 							[
@@ -20210,47 +20251,49 @@ var $author$project$Pages$TaskList$taskList = function (model) {
 								$mdgriffith$elm_ui$Element$alignTop
 							]),
 						A2($elm$core$List$map, $author$project$Pages$TaskList$taskCard, model.tasks)),
+					A2(
+						$elm$core$Maybe$withDefault,
+						_List_Nil,
 						A2(
-						$mdgriffith$elm_ui$Element$column,
-						_List_fromArray(
-							[
-								$mdgriffith$elm_ui$Element$width(
-								$mdgriffith$elm_ui$Element$fillPortion(3)),
-								$mdgriffith$elm_ui$Element$height($mdgriffith$elm_ui$Element$fill),
-								$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill),
-								$mdgriffith$elm_ui$Element$spacing(10),
-								$mdgriffith$elm_ui$Element$padding(10)
-							]),
-						A2(
-							$elm$core$Maybe$withDefault,
-							_List_Nil,
-							A2(
-								$elm$core$Maybe$map,
-								function (selected) {
-									return _Utils_ap(
-										A4($author$project$Pages$TaskList$executionInput, model.inputState, model.formValues, model.taskValidationErrors, selected),
+							$elm$core$Maybe$map,
+							function (selected) {
+								return _List_fromArray(
+									[
+										A2(
+										$mdgriffith$elm_ui$Element$column,
 										_List_fromArray(
 											[
-												A2(
-												$mdgriffith$elm_ui$Element$row,
-												_List_fromArray(
-													[
-														$mdgriffith$elm_ui$Element$width(
-														A2($mdgriffith$elm_ui$Element$maximum, 300, $mdgriffith$elm_ui$Element$fill))
-													]),
-												_List_fromArray(
-													[
-														A3(
-														$author$project$Styled$submitButton,
-														$author$project$Pages$TaskList$allowTaskSubmit(model.activeSchema),
-														model.formValues,
-														$author$project$Types$CreateExecution(
-															A3($author$project$Pages$TaskList$toExecutionCreate, selected.name, selected.id, model.formValues)))
-													]))
-											]));
-								},
-								model.selectedTask)))
-					]))
+												$mdgriffith$elm_ui$Element$width(
+												$mdgriffith$elm_ui$Element$fillPortion(3)),
+												$mdgriffith$elm_ui$Element$height($mdgriffith$elm_ui$Element$fill),
+												$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill),
+												$mdgriffith$elm_ui$Element$spacing(10),
+												$mdgriffith$elm_ui$Element$padding(10)
+											]),
+										_Utils_ap(
+											A4($author$project$Pages$TaskList$executionInput, model.inputState, model.formValues, model.taskValidationErrors, selected),
+											_List_fromArray(
+												[
+													A2(
+													$mdgriffith$elm_ui$Element$row,
+													_List_fromArray(
+														[
+															$mdgriffith$elm_ui$Element$width(
+															A2($mdgriffith$elm_ui$Element$maximum, 300, $mdgriffith$elm_ui$Element$fill))
+														]),
+													_List_fromArray(
+														[
+															A3(
+															$author$project$Styled$submitButton,
+															$author$project$Pages$TaskList$allowTaskSubmit(model.activeSchema),
+															model.formValues,
+															$author$project$Types$CreateExecution(
+																A3($author$project$Pages$TaskList$toExecutionCreate, selected.name, selected.id, model.formValues)))
+														]))
+												])))
+									]);
+							},
+							model.selectedTask))))
 			]));
 };
 var $author$project$Main$view = function (model) {

--- a/granary-ui/elm.json
+++ b/granary-ui/elm.json
@@ -22,6 +22,7 @@
             "lukewestby/elm-http-builder": "7.0.0",
             "mdgriffith/elm-ui": "1.1.5",
             "mgold/elm-geojson": "2.0.1",
+            "myrho/elm-round": "1.0.4",
             "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {

--- a/granary-ui/elm.json
+++ b/granary-ui/elm.json
@@ -11,6 +11,7 @@
             "danyx23/elm-uuid": "2.1.2",
             "elm/browser": "1.0.2",
             "elm/core": "1.0.4",
+            "elm/file": "1.0.5",
             "elm/html": "1.0.0",
             "elm/http": "2.0.0",
             "elm/json": "1.1.2",
@@ -20,12 +21,12 @@
             "elm-community/maybe-extra": "5.2.0",
             "lukewestby/elm-http-builder": "7.0.0",
             "mdgriffith/elm-ui": "1.1.5",
+            "mgold/elm-geojson": "2.0.1",
             "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
             "NoRedInk/elm-json-decode-pipeline": "1.0.0",
             "elm/bytes": "1.0.8",
-            "elm/file": "1.0.5",
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",

--- a/granary-ui/src/FileInput.elm
+++ b/granary-ui/src/FileInput.elm
@@ -1,0 +1,49 @@
+module FileInput exposing (InputEventHandler, view)
+
+import File exposing (File)
+import Html exposing (Attribute, Html, button, div, text)
+import Html.Attributes exposing (style)
+import Html.Events exposing (onClick, preventDefaultOn)
+import Json.Decode as D
+
+
+type alias InputEventHandler msg =
+    { onEnter : msg
+    , onOver : msg
+    , onLeave : msg
+    , onDrop : File -> List File -> msg
+    , onPick : msg
+    }
+
+
+hijackOn : String -> D.Decoder msg -> Attribute msg
+hijackOn event decoder =
+    preventDefaultOn event (D.map hijack decoder)
+
+
+hijack : msg -> ( msg, Bool )
+hijack msg =
+    ( msg, True )
+
+
+dropDecoder : (File -> List File -> msg) -> D.Decoder msg
+dropDecoder f =
+    D.at [ "dataTransfer", "files" ] (D.oneOrMore f File.decoder)
+
+
+view : InputEventHandler msg -> Html msg
+view handler =
+    div
+        [ style "border-radius" "20px"
+        , style "padding" "5px"
+        , style "display" "flex"
+        , style "flex-direction" "column"
+        , style "justify-content" "center"
+        , style "align-items" "center"
+        , hijackOn "dragenter" (D.succeed handler.onEnter)
+        , hijackOn "dragover" (D.succeed handler.onOver)
+        , hijackOn "dragleave" (D.succeed handler.onLeave)
+        , hijackOn "drop" (dropDecoder handler.onDrop)
+        ]
+        [ button [ onClick handler.onPick ] [ text "Select or drag and drop a task grid geojson" ]
+        ]

--- a/granary-ui/src/Main.elm
+++ b/granary-ui/src/Main.elm
@@ -600,21 +600,11 @@ logo attrs maxSize =
 
 logoTop : List (Element Msg) -> Element Msg
 logoTop rest =
-    column [ width fill, Element.centerX ] <|
-        [ row [ Element.centerX, Element.maximum 400 fill |> width ] <|
-            [ column [ width (fillPortion 9), height fill ]
-                [ logo
-                    [ width fill ]
-                    100
-                ]
-            , column [ width (fillPortion 1), height fill ]
-                [ row [ Element.centerY ]
-                    [ homeLink
-                    ]
-                ]
-            ]
-        ]
-            ++ rest
+    column [ Element.maximum 1024 fill |> width, Element.centerX ] <|
+        logo
+            [ width fill ]
+            100
+            :: rest
 
 
 
@@ -623,7 +613,7 @@ logoTop rest =
 
 homeLink : Element Msg
 homeLink =
-    Input.button []
+    Input.button [ Element.alignRight, padding 12 ]
         { onPress = Just GoHome
         , label = text "🏠"
         }
@@ -651,13 +641,24 @@ view model =
                     taskList tlm
             in
             { title = "Available Tasks"
-            , body = [ Element.layout [ Element.minimum 1024 fill |> width ] (logoTop [ taskListBody ]) ]
+            , body =
+                [ Element.layout
+                    [ Element.inFront homeLink
+                    , Element.minimum 1024 fill |> width
+                    ]
+                    (logoTop [ taskListBody ])
+                ]
             }
 
         ( ExecutionList elm, Just _ ) ->
             { title = "Execution list"
             , body =
-                [ Element.layout [ Element.minimum 1024 fill |> width ] <| logoTop [ executionList elm ]
+                [ Element.layout
+                    [ Element.inFront homeLink
+                    , Element.minimum 1024 fill |> width
+                    ]
+                  <|
+                    logoTop [ executionList elm ]
                 ]
             }
 

--- a/granary-ui/src/Main.elm
+++ b/granary-ui/src/Main.elm
@@ -473,7 +473,7 @@ update msg model =
             ( model, Nav.pushUrl model.key (Url.toString { baseUrl | query = Just newQp }) )
 
         GoHome ->
-            ( { model | route = Login }, Nav.pushUrl model.key "/tasks" )
+            ( { model | route = TaskList emptyTaskListModel }, Nav.pushUrl model.key "/tasks" )
 
         NameExecution s ->
             let
@@ -508,11 +508,17 @@ update msg model =
                         addition =
                             Dict.singleton "TASK_GRID" (Result.Ok (GeoJson.encode taskGrid))
 
+                        newTaskValidationErrors =
+                            Dict.remove "TASK_GRID" tlm.taskValidationErrors
+
                         newFormValues =
                             { formValues | fromSchema = Dict.union addition formValues.fromSchema }
 
                         updated =
-                            { tlm | formValues = newFormValues }
+                            { tlm
+                                | formValues = newFormValues
+                                , taskValidationErrors = newTaskValidationErrors
+                            }
                     in
                     ( { model | route = TaskList updated }, Cmd.none )
 

--- a/granary-ui/src/Main.elm
+++ b/granary-ui/src/Main.elm
@@ -281,14 +281,22 @@ update msg model =
 
         GotExecutions taskId (Ok executionsPage) ->
             let
-                withExecutions =
+                executionListModelUpdate =
+                    \elm ->
+                        { elm
+                            | executions = executionsPage.results
+                            , forTask = taskId
+                        }
+
+                freshExecutionListModel =
                     emptyExecutionListModel
-                        |> (\elm ->
-                                { elm
-                                    | executions = executionsPage.results
-                                    , forTask = taskId
-                                }
-                           )
+                        |> executionListModelUpdate
+
+                withExecutions =
+                    updateExecutionListModel
+                        executionListModelUpdate
+                        model.route
+                        |> Maybe.withDefault freshExecutionListModel
             in
             ( { model
                 | route = ExecutionList withExecutions

--- a/granary-ui/src/Main.elm
+++ b/granary-ui/src/Main.elm
@@ -565,7 +565,9 @@ update msg model =
                 cmd =
                     case event of
                         Pick ->
-                            Select.files [ "*.geojson", "*.json" ] GotFiles
+                            Select.files
+                                [ "application/geo+json", "application/json" ]
+                                GotFiles
 
                         _ ->
                             Cmd.none

--- a/granary-ui/src/Main.elm
+++ b/granary-ui/src/Main.elm
@@ -36,8 +36,7 @@ import Result
 import Set as Set
 import String
 import Styled exposing (submitButton, textInput)
-import Time
-import Types exposing (GranaryToken, Msg(..), PaginatedResponse)
+import Types exposing (ExecutionCreate, GranaryExecution, GranaryToken, Msg(..), PaginatedResponse, StacAsset)
 import Url
 import Url.Parser as Parser exposing ((<?>))
 import Url.Parser.Query as Query
@@ -53,33 +52,6 @@ type alias Model =
     , route : Route
     , secrets : Maybe GranaryToken
     , secretsUnsubmitted : Maybe GranaryToken
-    }
-
-
-type alias StacAsset =
-    { href : String
-    , title : Maybe String
-    , description : Maybe String
-    , roles : List String
-    , mediaType : String
-    }
-
-
-type alias GranaryExecution =
-    { id : Uuid.Uuid
-    , taskId : Uuid.Uuid
-    , invokedAt : Time.Posix
-    , statusReason : Maybe String
-    , results : List StacAsset
-    , webhookId : Maybe Uuid.Uuid
-    , name : String
-    }
-
-
-type alias ExecutionCreate =
-    { name : String
-    , taskId : Uuid.Uuid
-    , arguments : JD.Value
     }
 
 

--- a/granary-ui/src/Main.elm
+++ b/granary-ui/src/Main.elm
@@ -2,24 +2,20 @@ module Main exposing (main)
 
 import Browser
 import Browser.Navigation as Nav
-import Dict exposing (Dict)
+import Dict as Dict
 import Element
     exposing
         ( Element
         , column
-        , el
         , fill
         , fillPortion
         , height
         , padding
-        , rgb255
         , row
         , spacing
         , text
         , width
         )
-import Element.Background as Background
-import Element.Border as Border
 import Element.Font as Font
 import Element.Input as Input
 import Framework.Card as Card
@@ -37,13 +33,13 @@ import Json.Schema.Definitions as Schema
         )
 import Json.Schema.Validation as Validation
 import Maybe.Extra exposing (orElse)
-import Pages.TaskList exposing (FormValues, TaskListModel, decoderGranaryTask, emptyFormValues, emptyTaskListModel, showType, taskList)
+import Pages.TaskList exposing (TaskListModel, decoderGranaryTask, emptyFormValues, emptyTaskListModel, showType, taskList)
 import Result
 import Set exposing (Set)
 import String
 import Styled exposing (styledPrimaryText, styledSecondaryText, submitButton, textInput)
 import Time
-import Types exposing (GranaryTask, GranaryToken, Msg(..), PaginatedResponse)
+import Types exposing (GranaryToken, Msg(..), PaginatedResponse)
 import Url
 import Url.Parser as Parser exposing ((<?>))
 import Url.Parser.Query as Query
@@ -601,14 +597,6 @@ homeLink =
     Input.button []
         { onPress = Just GoHome
         , label = text "🏠"
-        }
-
-
-pageLink : Maybe GranaryToken -> Element Msg
-pageLink secrets =
-    Input.button []
-        { onPress = secrets |> Maybe.map AddTokenParam
-        , label = text "🔗"
         }
 
 

--- a/granary-ui/src/Main.elm
+++ b/granary-ui/src/Main.elm
@@ -248,7 +248,7 @@ update msg model =
                 Browser.External href ->
                     ( model, Nav.load href )
 
-        TaskSelect task ->
+        NewExecutionForTask task ->
             let
                 newRoute =
                     updateTaskListModel
@@ -617,6 +617,10 @@ logoTop rest =
             ++ rest
 
 
+
+-- to top left or top right
+
+
 homeLink : Element Msg
 homeLink =
     Input.button []
@@ -627,13 +631,11 @@ homeLink =
 
 loginPage : Model -> Element Msg
 loginPage model =
-    column [ spacing 3, Element.centerX, Element.centerY, width Element.shrink ]
+    column [ spacing 24, Element.centerX, Element.centerY, width Element.shrink ]
         [ row [ width fill ] [ logo [] 200 ]
-        , row [ width fill ]
+        , row [ width fill, spacing 8 ]
             [ textInput [] TokenInput model.secretsUnsubmitted "Enter a token" "Token input"
-            ]
-        , row [ width fill ]
-            [ submitButton (not << String.isEmpty)
+            , submitButton (not << String.isEmpty)
                 (Maybe.withDefault "" model.secretsUnsubmitted)
                 TokenSubmit
             ]
@@ -649,20 +651,20 @@ view model =
                     taskList tlm
             in
             { title = "Available Tasks"
-            , body = [ Element.layout [] (logoTop [ taskListBody ]) ]
+            , body = [ Element.layout [ Element.minimum 1024 fill |> width ] (logoTop [ taskListBody ]) ]
             }
 
         ( ExecutionList elm, Just _ ) ->
             { title = "Execution list"
             , body =
-                [ Element.layout [] <| logoTop [ executionList elm ]
+                [ Element.layout [ Element.minimum 1024 fill |> width ] <| logoTop [ executionList elm ]
                 ]
             }
 
         _ ->
             { title = "Granary Model Dashboard"
             , body =
-                [ Element.layout [] <| loginPage model
+                [ Element.layout [ Element.minimum 1024 fill |> width ] <| loginPage model
                 ]
             }
 

--- a/granary-ui/src/Pages/ExecutionList.elm
+++ b/granary-ui/src/Pages/ExecutionList.elm
@@ -4,7 +4,6 @@ import Element exposing (Element, column, fill, padding, row, spacing, text, wid
 import Element.Font as Font
 import Element.Input as Input
 import Framework.Card as Card
-import Html.Attributes as HA
 import Maybe.Extra exposing (orElse)
 import Set exposing (Set)
 import Styled exposing (styledPrimaryText, textInput)
@@ -77,17 +76,21 @@ executionAssets showAssets execution =
 
 executionAssetsList : GranaryExecution -> List StacAsset -> List (Element Msg)
 executionAssetsList execution =
+    let
+        assetName asset =
+            asset.title
+                |> orElse asset.description
+                |> Maybe.withDefault
+                    (asset.roles |> List.intersperse ", " |> String.concat)
+    in
     List.map
         (\asset ->
-            Element.link [ Element.htmlAttribute <| HA.download execution.name ]
+            Element.downloadAs []
                 { url = asset.href
+                , filename = execution.name
                 , label =
                     styledPrimaryText [ Font.underline ]
-                        (asset.title
-                            |> orElse asset.description
-                            |> Maybe.withDefault
-                                (asset.roles |> List.intersperse ", " |> String.concat)
-                        )
+                        (assetName asset)
                 }
         )
 

--- a/granary-ui/src/Pages/ExecutionList.elm
+++ b/granary-ui/src/Pages/ExecutionList.elm
@@ -1,0 +1,139 @@
+module Pages.ExecutionList exposing (ExecutionListModel, emptyExecutionListModel, executionList)
+
+import Element exposing (Element, column, fill, padding, row, spacing, text, width)
+import Element.Font as Font
+import Element.Input as Input
+import Framework.Card as Card
+import Maybe.Extra exposing (orElse)
+import Set exposing (Set)
+import Styled exposing (styledPrimaryText, textInput)
+import Types exposing (GranaryExecution, Msg(..), StacAsset)
+import Uuid as Uuid
+
+
+
+-- Model
+
+
+type alias ExecutionListModel =
+    { selectedExecutions : Set String
+    , executionNameSearch : Maybe String
+    , executions : List GranaryExecution
+    , forTask : Maybe Uuid.Uuid
+    }
+
+
+emptyExecutionListModel : ExecutionListModel
+emptyExecutionListModel =
+    { selectedExecutions = Set.empty
+    , executionNameSearch = Maybe.Nothing
+    , executions = []
+    , forTask = Nothing
+    }
+
+
+
+-- Helper functions
+
+
+toEmoji : GranaryExecution -> String
+toEmoji execution =
+    case ( execution.statusReason, execution.results ) of
+        ( Just _, _ ) ->
+            "❌"
+
+        ( _, _ :: _ ) ->
+            "✅"
+
+        _ ->
+            "🏃\u{200D}♀️"
+
+
+
+-- View
+
+
+executionAssets : Bool -> GranaryExecution -> List (Element Msg)
+executionAssets showAssets execution =
+    if List.isEmpty execution.results then
+        []
+
+    else
+        row []
+            [ Input.button []
+                { onPress = ToggleShowAssets execution.id |> Just
+                , label = text "➕"
+                }
+            , styledPrimaryText [] " Show assets"
+            ]
+            :: (if showAssets then
+                    executionAssetsList execution.results
+
+                else
+                    []
+               )
+
+
+executionAssetsList : List StacAsset -> List (Element Msg)
+executionAssetsList =
+    List.map
+        (\asset ->
+            Element.link []
+                { url = asset.href
+                , label =
+                    styledPrimaryText [ Font.underline ]
+                        (asset.title
+                            |> orElse asset.description
+                            |> Maybe.withDefault
+                                (asset.roles |> List.intersperse ", " |> String.concat)
+                        )
+                }
+        )
+
+
+nameSearchInput : Maybe String -> Element Msg
+nameSearchInput currValue =
+    textInput
+        [ width fill ]
+        SearchExecutionName
+        currValue
+        "Name like"
+        "Search"
+        |> List.singleton
+        |> row [ width fill ]
+
+
+executionCard : Bool -> GranaryExecution -> Element Msg
+executionCard showAssets execution =
+    [ column
+        (width
+            (fill
+                |> Element.minimum 350
+                |> Element.maximum 400
+            )
+            :: spacing 5
+            :: Card.simple
+        )
+        ([ row [] [ styledPrimaryText [] execution.name ]
+         , row [] [ styledPrimaryText [] ("Status: " ++ toEmoji execution) ]
+         ]
+            ++ executionAssets showAssets execution
+        )
+    ]
+        |> row [ width fill ]
+
+
+executionList : ExecutionListModel -> Element Msg
+executionList model =
+    let
+        showAssets execution =
+            Set.member (Uuid.toString execution.id) model.selectedExecutions
+
+        card execution =
+            executionCard (showAssets execution) execution
+    in
+    nameSearchInput model.executionNameSearch
+        :: (model.executions
+                |> List.map card
+           )
+        |> column [ Element.centerX, spacing 10, padding 15 ]

--- a/granary-ui/src/Pages/ExecutionList.elm
+++ b/granary-ui/src/Pages/ExecutionList.elm
@@ -26,7 +26,7 @@ type alias ExecutionListModel =
 emptyExecutionListModel : ExecutionListModel
 emptyExecutionListModel =
     { selectedExecutions = Set.empty
-    , executionNameSearch = Maybe.Nothing
+    , executionNameSearch = Nothing
     , executions = []
     , forTask = Nothing
     }

--- a/granary-ui/src/Pages/ExecutionList.elm
+++ b/granary-ui/src/Pages/ExecutionList.elm
@@ -4,6 +4,7 @@ import Element exposing (Element, column, fill, padding, row, spacing, text, wid
 import Element.Font as Font
 import Element.Input as Input
 import Framework.Card as Card
+import Html.Attributes as HA
 import Maybe.Extra exposing (orElse)
 import Set exposing (Set)
 import Styled exposing (styledPrimaryText, textInput)
@@ -40,13 +41,13 @@ toEmoji : GranaryExecution -> String
 toEmoji execution =
     case ( execution.statusReason, execution.results ) of
         ( Just _, _ ) ->
-            "❌"
+            "❌ Failed"
 
         ( _, _ :: _ ) ->
-            "✅"
+            "✅ Succeeded"
 
         _ ->
-            "🏃\u{200D}♀️"
+            "🏃\u{200D}♀️ Running"
 
 
 
@@ -59,7 +60,7 @@ executionAssets showAssets execution =
         []
 
     else
-        row []
+        row [ spacing 3 ]
             [ Input.button []
                 { onPress = ToggleShowAssets execution.id |> Just
                 , label = text "➕"
@@ -67,18 +68,18 @@ executionAssets showAssets execution =
             , styledPrimaryText [] " Show assets"
             ]
             :: (if showAssets then
-                    executionAssetsList execution.results
+                    executionAssetsList execution execution.results
 
                 else
                     []
                )
 
 
-executionAssetsList : List StacAsset -> List (Element Msg)
-executionAssetsList =
+executionAssetsList : GranaryExecution -> List StacAsset -> List (Element Msg)
+executionAssetsList execution =
     List.map
         (\asset ->
-            Element.link []
+            Element.link [ Element.htmlAttribute <| HA.download execution.name ]
                 { url = asset.href
                 , label =
                     styledPrimaryText [ Font.underline ]
@@ -97,7 +98,7 @@ nameSearchInput currValue =
         [ width fill ]
         SearchExecutionName
         currValue
-        "Name like"
+        "Search"
         "Search"
         |> List.singleton
         |> row [ width fill ]
@@ -114,7 +115,7 @@ executionCard showAssets execution =
             :: spacing 5
             :: Card.simple
         )
-        ([ row [] [ styledPrimaryText [] execution.name ]
+        ([ row [] [ styledPrimaryText [ Font.bold ] execution.name ]
          , row [] [ styledPrimaryText [] ("Status: " ++ toEmoji execution) ]
          ]
             ++ executionAssets showAssets execution

--- a/granary-ui/src/Pages/TaskList.elm
+++ b/granary-ui/src/Pages/TaskList.elm
@@ -443,7 +443,7 @@ schemaToForm inputEvent formValues errors schema =
         inputRow ( k, propSchema ) =
             case propSchema of
                 ObjectSchema subSchema ->
-                    column [ width fill ]
+                    column [ width fill, spacing 5 ]
                         (toInput ( k, subSchema )
                             :: errs ( k, subSchema )
                         )

--- a/granary-ui/src/Pages/TaskList.elm
+++ b/granary-ui/src/Pages/TaskList.elm
@@ -30,6 +30,8 @@ import Element.Font as Font
 import Element.Input as Input
 import FileInput as FileInput
 import Framework.Button as Button
+import Html as Html
+import Html.Attributes as HA
 import Json.Decode as JD
 import Json.Encode as JE
 import Json.Schema as Schema
@@ -40,7 +42,7 @@ import Json.Schema.Definitions as Schema
         , Type(..)
         )
 import Json.Schema.Validation as Validation
-import Styled exposing (primary, secondaryShadow, styledPrimaryText, styledSecondaryText, submitButton, textInput)
+import Styled exposing (secondaryShadow, styledPrimaryText, styledSecondaryText, submitButton, textInput)
 import Types exposing (ExecutionCreate, ExecutionCreateError(..), GranaryTask, InputEvent(..), Msg(..))
 import Urls exposing (executionsUrl)
 import Uuid as Uuid
@@ -305,42 +307,27 @@ getErrField err =
                 |> String.concat
 
 
-taskCard : Maybe Uuid.Uuid -> GranaryTask -> Element Msg
-taskCard selectedId task =
+taskCard : GranaryTask -> Element Msg
+taskCard task =
     column (width fill :: spacing 5 :: Element.centerY :: Button.simple)
-        [ row
-            (Font.color primary
-                :: (if Just task.id == selectedId then
-                        [ secondaryShadow ]
-
-                    else
-                        []
-                   )
-            )
-            [ Input.button
-                []
-                { label = text task.name
-                , onPress = TaskSelect task |> Just
+        [ row [ width fill, spacing 3 ]
+            [ styledPrimaryText [ Element.alignLeft ] task.name
+            , Input.button
+                [ Element.alignRight, Element.htmlAttribute <| HA.style "margin" "0 12px" ]
+                { label = text "➕"
+                , onPress = NewExecutionForTask task |> Just
                 }
+            , tasksLink task
             ]
-        , tasksLink selectedId task
         ]
 
 
-tasksLink : Maybe Uuid.Uuid -> GranaryTask -> Element Msg
-tasksLink selectedId task =
-    if selectedId == Just task.id then
-        row [ width fill ]
-            [ row []
-                [ Element.link []
-                    { url = executionsUrl Nothing (Just task.id)
-                    , label = styledSecondaryText [ Font.underline ] "Executions"
-                    }
-                ]
-            ]
-
-    else
-        row [] []
+tasksLink : GranaryTask -> Element Msg
+tasksLink task =
+    Element.link []
+        { url = executionsUrl Nothing (Just task.id)
+        , label = styledSecondaryText [ Font.underline ] "Executions"
+        }
 
 
 makeHelpfulErrorMessage : ExecutionCreateError -> List (Element Msg)
@@ -494,17 +481,16 @@ executionInput inputEvent formValues errors task =
 taskList : TaskListModel -> Element Msg
 taskList model =
     row [ Element.centerX ]
-        [ column
+        [ -- tasks needs to be above the columns
+          Element.html (Html.h2 [] [ Html.text "Tasks" ])
+        , column
             [ fillPortion 1 |> width
             , spacing 10
             , padding 10
             , Element.alignTop
             ]
             (model.tasks
-                |> List.map
-                    (taskCard
-                        (Maybe.map .id model.selectedTask)
-                    )
+                |> List.map taskCard
             )
         , column
             [ fillPortion 3 |> width

--- a/granary-ui/src/Pages/TaskList.elm
+++ b/granary-ui/src/Pages/TaskList.elm
@@ -1,0 +1,470 @@
+module Pages.TaskList exposing
+    ( FormValues
+    , TaskListModel
+    , decoderGranaryTask
+    , emptyFormValues
+    , emptyTaskListModel
+    , showType
+    , taskList
+    )
+
+import Array
+import Dict exposing (Dict)
+import Element
+    exposing
+        ( Element
+        , column
+        , el
+        , fill
+        , fillPortion
+        , height
+        , padding
+        , rgb255
+        , row
+        , spacing
+        , text
+        , width
+        )
+import Element.Font as Font
+import Element.Input as Input
+import Framework.Button as Button
+import Json.Decode as JD
+import Json.Encode as JE
+import Json.Schema as Schema
+import Json.Schema.Definitions as Schema
+    exposing
+        ( Schema(..)
+        , SingleType(..)
+        , Type(..)
+        )
+import Json.Schema.Validation as Validation
+import Styled exposing (primary, secondaryShadow, styledPrimaryText, styledSecondaryText, submitButton, textInput)
+import Types exposing (ExecutionCreate, GranaryTask, GranaryToken, Msg(..))
+import Urls exposing (executionsUrl)
+import Uuid as Uuid
+
+
+
+-- MODEL
+
+
+type alias FormValues =
+    { fromSchema : Dict String (Result String JD.Value)
+    , executionName : Maybe String
+    }
+
+
+emptyFormValues : FormValues
+emptyFormValues =
+    { fromSchema = Dict.empty
+    , executionName = Nothing
+    }
+
+
+type alias ExecutionCreate =
+    { name : String
+    , taskId : Uuid.Uuid
+    , arguments : JD.Value
+    }
+
+
+type alias TaskListModel =
+    { tasks : List GranaryTask
+    , selectedTask : Maybe GranaryTask
+    , formValues : FormValues
+    , taskValidationErrors : Dict String (List Validation.Error)
+    , activeSchema : Maybe Schema.Schema
+    }
+
+
+emptyTaskListModel : TaskListModel
+emptyTaskListModel =
+    { tasks = []
+    , selectedTask = Nothing
+    , formValues = emptyFormValues
+    , taskValidationErrors = Dict.empty
+    , activeSchema = Nothing
+    }
+
+
+toExecutionCreate : String -> Uuid.Uuid -> FormValues -> ExecutionCreate
+toExecutionCreate fallbackName taskId formValues =
+    let
+        goodFields =
+            Dict.toList formValues.fromSchema
+                |> List.filterMap
+                    (\( k, v ) ->
+                        Result.toMaybe v
+                            |> Maybe.map (\goodVal -> ( k, goodVal ))
+                    )
+
+        executionName =
+            formValues.executionName |> Maybe.withDefault fallbackName
+    in
+    ExecutionCreate executionName taskId (JE.object goodFields)
+
+
+decoderGranaryTask : JD.Decoder GranaryTask
+decoderGranaryTask =
+    JD.map5
+        GranaryTask
+        (JD.field "id" Uuid.decoder)
+        (JD.field "name" JD.string)
+        (JD.field "validator" (JD.field "schema" Schema.decoder))
+        (JD.field "jobDefinition" JD.string)
+        (JD.field "jobQueue" JD.string)
+
+
+
+-- Pure transformation functions
+
+
+isOk : Result e a -> Bool
+isOk res =
+    case res of
+        Result.Ok _ ->
+            True
+
+        Result.Err _ ->
+            False
+
+
+toValue : Schema.SubSchema -> String -> Result String JD.Value
+toValue schema s =
+    encodeValue schema.type_ s
+
+
+encodeValue : Schema.Type -> String -> Result String JD.Value
+encodeValue t s =
+    let
+        defaulter =
+            toResult s
+    in
+    case t of
+        SingleType IntegerType ->
+            String.toInt s |> Maybe.map JE.int |> defaulter
+
+        SingleType NumberType ->
+            String.toFloat s |> Maybe.map JE.float |> defaulter
+
+        SingleType StringType ->
+            Just (JE.string s) |> defaulter
+
+        SingleType BooleanType ->
+            (case s of
+                "true" ->
+                    Just (JE.bool True)
+
+                "false" ->
+                    Just (JE.bool False)
+
+                _ ->
+                    Nothing
+            )
+                |> defaulter
+
+        SingleType ArrayType ->
+            Just (JE.array JE.string (String.split "," s |> Array.fromList)) |> defaulter
+
+        SingleType ObjectType ->
+            (case JD.decodeString (JD.dict JD.value) s of
+                Result.Ok v ->
+                    Just (JE.dict identity identity v)
+
+                _ ->
+                    Nothing
+            )
+                |> defaulter
+
+        SingleType NullType ->
+            Just JE.null |> defaulter
+
+        AnyType ->
+            Just (JE.string s) |> defaulter
+
+        NullableType st ->
+            case s of
+                "null" ->
+                    Just JE.null
+                        |> defaulter
+
+                _ ->
+                    encodeValue (SingleType st) s
+
+        UnionType sts ->
+            List.map (\st -> encodeValue (SingleType st) s) sts
+                |> List.filter isOk
+                |> List.head
+                |> Maybe.withDefault (Result.Err s)
+
+
+toResult : String -> Maybe JD.Value -> Result String JD.Value
+toResult s m =
+    case m of
+        Just v ->
+            Result.Ok v
+
+        Nothing ->
+            Result.Err s
+
+
+showType : Schema.Type -> String
+showType t =
+    case t of
+        SingleType IntegerType ->
+            "int"
+
+        SingleType NumberType ->
+            "float"
+
+        SingleType StringType ->
+            "string"
+
+        SingleType BooleanType ->
+            "boolean"
+
+        SingleType ArrayType ->
+            "array"
+
+        SingleType ObjectType ->
+            "object"
+
+        SingleType NullType ->
+            "null"
+
+        AnyType ->
+            "any"
+
+        NullableType st ->
+            "Maybe " ++ showType (SingleType st)
+
+        UnionType sts ->
+            List.map (showType << SingleType) sts
+                |> List.intersperse ", "
+                |> List.foldl (++) ""
+                |> (++) "one of "
+
+
+numProperties : Schema -> Int
+numProperties schema =
+    let
+        schemataLength (Schema.Schemata props) =
+            List.length props
+    in
+    case schema of
+        ObjectSchema subSchema ->
+            subSchema.properties |> Maybe.map schemataLength |> Maybe.withDefault 0
+
+        BooleanSchema _ ->
+            0
+
+
+allowTaskSubmit : Maybe Schema -> FormValues -> Bool
+allowTaskSubmit schema formValues =
+    case ( formValues.executionName, schema ) of
+        ( Nothing, _ ) ->
+            False
+
+        ( _, Nothing ) ->
+            False
+
+        ( Just s, Just schm ) ->
+            not (String.isEmpty s)
+                && List.foldl (\x y -> x && y) True (List.map isOk (Dict.values formValues.fromSchema))
+                && (Dict.size formValues.fromSchema
+                        == numProperties schm
+                   )
+
+
+
+-- VIEW
+
+
+fontRed : Element.Attr d m
+fontRed =
+    rgb255 255 0 0 |> Font.color
+
+
+getErrField : Validation.Error -> String
+getErrField err =
+    case err.jsonPointer.path of
+        [] ->
+            "ROOT"
+
+        errs ->
+            List.intersperse "." errs
+                |> String.concat
+
+
+taskCard : Maybe Uuid.Uuid -> GranaryTask -> Element Msg
+taskCard selectedId task =
+    column (width fill :: spacing 5 :: Element.centerY :: Button.simple)
+        [ row
+            (Font.color primary
+                :: (if Just task.id == selectedId then
+                        [ secondaryShadow ]
+
+                    else
+                        []
+                   )
+            )
+            [ Input.button
+                []
+                { label = text task.name
+                , onPress = TaskSelect task |> Just
+                }
+            ]
+        , tasksLink selectedId task
+        ]
+
+
+tasksLink : Maybe Uuid.Uuid -> GranaryTask -> Element Msg
+tasksLink selectedId task =
+    if selectedId == Just task.id then
+        row [ width fill ]
+            [ row []
+                [ Element.link []
+                    { url = executionsUrl Nothing (Just task.id)
+                    , label = styledSecondaryText [ Font.underline ] "Executions"
+                    }
+                ]
+            ]
+
+    else
+        row [] []
+
+
+makeErr : Validation.Error -> List (Element Msg)
+makeErr err =
+    case err.details of
+        Validation.Required fields ->
+            fields
+                |> List.map (\s -> row [] [ text "Missing field: ", Element.el [ fontRed ] (text s) ])
+
+        Validation.AlwaysFail ->
+            [ row [] [ text "Invalid json" ] ]
+
+        Validation.InvalidType t ->
+            [ text t ]
+
+        Validation.RequiredProperty ->
+            []
+
+        _ ->
+            [ ("I can't tell what else is wrong with " ++ getErrField err)
+                |> text
+            ]
+
+
+schemaToForm : Dict String (Result String JD.Value) -> Dict String (List Validation.Error) -> Schema.SubSchema -> List (Element Msg)
+schemaToForm formValues errors schema =
+    let
+        errs ( k, _ ) =
+            Dict.get k errors |> Maybe.withDefault [] |> List.concatMap makeErr
+
+        toInput ( k, v ) =
+            if String.toLower k /= "task_grid" then
+                textInput [ width (Element.minimum 300 fill) ]
+                    (\s ->
+                        ValidateWith
+                            { schema = v
+                            , fieldName = k
+                            , fieldValue = toValue v s
+                            }
+                    )
+                    (case Dict.get k formValues of
+                        Just (Result.Ok jsonValue) ->
+                            Just
+                                (JE.encode 0 jsonValue
+                                    |> String.toList
+                                    |> List.filter ((/=) '"')
+                                    |> String.fromList
+                                )
+
+                        Just (Result.Err s) ->
+                            Just s
+
+                        _ ->
+                            Nothing
+                    )
+                    (k ++ ": " ++ showType v.type_)
+                    k
+
+            else
+                row [] [ text "file input goes here" ]
+
+        inputRow ( k, propSchema ) =
+            case propSchema of
+                ObjectSchema subSchema ->
+                    column [ spacing 10 ]
+                        [ row [] [ toInput ( k, subSchema ) ]
+                        , row [] (errs ( k, subSchema ))
+                        ]
+
+                BooleanSchema _ ->
+                    row [ spacing 5 ] [ toInput ( k, Schema.blankSubSchema ) ]
+
+        makeInput (Schema.Schemata definitions) =
+            List.map inputRow definitions
+    in
+    schema.properties
+        |> Maybe.map makeInput
+        |> Maybe.withDefault []
+
+
+executionInput : FormValues -> Dict String (List Validation.Error) -> GranaryTask -> List (Element Msg)
+executionInput formValues errors task =
+    case task.validator of
+        BooleanSchema _ ->
+            [ Element.el [] (text "oh no -- this task's schema decoded as a \"BooleanSchema\"") ]
+
+        ObjectSchema subSchema ->
+            textInput [ width (Element.minimum 300 fill) ]
+                NameExecution
+                formValues.executionName
+                "Execution name"
+                "New execution name"
+                :: schemaToForm
+                    formValues.fromSchema
+                    errors
+                    subSchema
+
+
+taskList : TaskListModel -> Element Msg
+taskList model =
+    row [ Element.centerX ]
+        [ column
+            [ fillPortion 1 |> width
+            , spacing 10
+            , padding 10
+            , Element.alignTop
+            ]
+            (model.tasks
+                |> List.map
+                    (taskCard
+                        (Maybe.map .id model.selectedTask)
+                    )
+            )
+        , column
+            [ fillPortion 3 |> width
+            , height fill
+            , spacing 10
+            , padding 10
+            ]
+            (Maybe.withDefault
+                [ styledPrimaryText [] "👈 Choose a task on the left" ]
+                (model.selectedTask
+                    |> Maybe.map
+                        (\selected ->
+                            executionInput model.formValues model.taskValidationErrors selected
+                                ++ [ row []
+                                        [ submitButton (allowTaskSubmit model.activeSchema)
+                                            model.formValues
+                                            "Some inputs are invalid"
+                                            (toExecutionCreate selected.name selected.id model.formValues |> CreateExecution)
+                                        ]
+                                   ]
+                        )
+                )
+            )
+        ]

--- a/granary-ui/src/Pages/TaskList.elm
+++ b/granary-ui/src/Pages/TaskList.elm
@@ -419,7 +419,14 @@ schemaToForm inputEvent formValues errors schema =
                         (\result ->
                             case result of
                                 Result.Ok data ->
-                                    always (row [] [ text "Successful geojson upload!" ] |> Just) data
+                                    always
+                                        (row []
+                                            [ styledPrimaryText []
+                                                "Successful geojson upload!"
+                                            ]
+                                            |> Just
+                                        )
+                                        data
 
                                 Result.Err _ ->
                                     Nothing

--- a/granary-ui/src/Pages/TaskList.elm
+++ b/granary-ui/src/Pages/TaskList.elm
@@ -443,10 +443,10 @@ schemaToForm inputEvent formValues errors schema =
         inputRow ( k, propSchema ) =
             case propSchema of
                 ObjectSchema subSchema ->
-                    column [ spacing 10 ]
-                        [ row [] [ toInput ( k, subSchema ) ]
-                        , row [] (errs ( k, subSchema ))
-                        ]
+                    column [ width fill ]
+                        (toInput ( k, subSchema )
+                            :: errs ( k, subSchema )
+                        )
 
                 BooleanSchema _ ->
                     row [ spacing 5 ] [ toInput ( k, Schema.blankSubSchema ) ]
@@ -480,38 +480,39 @@ executionInput inputEvent formValues errors task =
 
 taskList : TaskListModel -> Element Msg
 taskList model =
-    row [ Element.centerX ]
-        [ -- tasks needs to be above the columns
-          Element.html (Html.h2 [] [ Html.text "Tasks" ])
-        , column
-            [ fillPortion 1 |> width
-            , spacing 10
-            , padding 10
-            , Element.alignTop
-            ]
-            (model.tasks
-                |> List.map taskCard
-            )
-        , column
-            [ fillPortion 3 |> width
-            , height fill
-            , width fill
-            , spacing 10
-            , padding 10
-            ]
-            (Maybe.withDefault
-                [ styledPrimaryText [ width fill ] "👈 Choose a task on the left" ]
-                (model.selectedTask
-                    |> Maybe.map
-                        (\selected ->
-                            executionInput model.inputState model.formValues model.taskValidationErrors selected
-                                ++ [ row [ width (Element.maximum 300 fill) ]
-                                        [ submitButton (allowTaskSubmit model.activeSchema)
-                                            model.formValues
-                                            (toExecutionCreate selected.name selected.id model.formValues |> CreateExecution)
-                                        ]
-                                   ]
-                        )
+    column [ Element.centerX ]
+        [ row [ Element.centerX, width fill ] [ Element.html (Html.h2 [] [ Html.text "Tasks" ]) ]
+        , row [ width fill ]
+            [ column
+                [ fillPortion 1 |> width
+                , spacing 10
+                , padding 10
+                , Element.alignTop
+                ]
+                (model.tasks
+                    |> List.map taskCard
                 )
-            )
+            , column
+                [ fillPortion 3 |> width
+                , height fill
+                , width fill
+                , spacing 10
+                , padding 10
+                ]
+                (Maybe.withDefault
+                    []
+                    (model.selectedTask
+                        |> Maybe.map
+                            (\selected ->
+                                executionInput model.inputState model.formValues model.taskValidationErrors selected
+                                    ++ [ row [ width (Element.maximum 300 fill) ]
+                                            [ submitButton (allowTaskSubmit model.activeSchema)
+                                                model.formValues
+                                                (toExecutionCreate selected.name selected.id model.formValues |> CreateExecution)
+                                            ]
+                                       ]
+                            )
+                    )
+                )
+            ]
         ]

--- a/granary-ui/src/Pages/TaskList.elm
+++ b/granary-ui/src/Pages/TaskList.elm
@@ -30,7 +30,6 @@ import Element.Font as Font
 import Element.Input as Input
 import FileInput as FileInput
 import Framework.Button as Button
-import Html as Html
 import Html.Attributes as HA
 import Json.Decode as JD
 import Json.Encode as JE
@@ -480,10 +479,10 @@ executionInput inputEvent formValues errors task =
 
 taskList : TaskListModel -> Element Msg
 taskList model =
-    column [ Element.centerX ]
-        [ row [ Element.centerX, width fill ] [ Element.html (Html.h2 [] [ Html.text "Tasks" ]) ]
+    column [ width fill ]
+        [ row [ width fill ] [ styledPrimaryText [ Font.bold, Font.size 24, Element.centerX ] "Tasks" ]
         , row [ width fill ]
-            [ column
+            (column
                 [ fillPortion 1 |> width
                 , spacing 10
                 , padding 10
@@ -492,27 +491,27 @@ taskList model =
                 (model.tasks
                     |> List.map taskCard
                 )
-            , column
-                [ fillPortion 3 |> width
-                , height fill
-                , width fill
-                , spacing 10
-                , padding 10
-                ]
-                (Maybe.withDefault
-                    []
-                    (model.selectedTask
+                :: (model.selectedTask
                         |> Maybe.map
                             (\selected ->
-                                executionInput model.inputState model.formValues model.taskValidationErrors selected
-                                    ++ [ row [ width (Element.maximum 300 fill) ]
-                                            [ submitButton (allowTaskSubmit model.activeSchema)
-                                                model.formValues
-                                                (toExecutionCreate selected.name selected.id model.formValues |> CreateExecution)
-                                            ]
-                                       ]
+                                [ column
+                                    [ fillPortion 3 |> width
+                                    , height fill
+                                    , width fill
+                                    , spacing 10
+                                    , padding 10
+                                    ]
+                                    (executionInput model.inputState model.formValues model.taskValidationErrors selected
+                                        ++ [ row [ width (Element.maximum 300 fill) ]
+                                                [ submitButton (allowTaskSubmit model.activeSchema)
+                                                    model.formValues
+                                                    (toExecutionCreate selected.name selected.id model.formValues |> CreateExecution)
+                                                ]
+                                           ]
+                                    )
+                                ]
                             )
-                    )
-                )
-            ]
+                        |> Maybe.withDefault []
+                   )
+            )
         ]

--- a/granary-ui/src/Pages/TaskList.elm
+++ b/granary-ui/src/Pages/TaskList.elm
@@ -116,7 +116,7 @@ decoderGranaryTask =
 
 
 
--- Pure transformation functions
+-- Helper functions
 
 
 isOk : Result e a -> Bool

--- a/granary-ui/src/Pages/TaskList.elm
+++ b/granary-ui/src/Pages/TaskList.elm
@@ -39,7 +39,7 @@ import Json.Schema.Definitions as Schema
         )
 import Json.Schema.Validation as Validation
 import Styled exposing (primary, secondaryShadow, styledPrimaryText, styledSecondaryText, submitButton, textInput)
-import Types exposing (ExecutionCreate, GranaryTask, GranaryToken, Msg(..))
+import Types exposing (ExecutionCreate, GranaryTask, Msg(..))
 import Urls exposing (executionsUrl)
 import Uuid as Uuid
 

--- a/granary-ui/src/Pages/TaskList.elm
+++ b/granary-ui/src/Pages/TaskList.elm
@@ -350,7 +350,7 @@ makeHelpfulErrorMessage err =
             List.concatMap makeErr errs
 
         DecodingError _ ->
-            [ row [] [ text "Structure of JSON in this field was unexpected" ] ]
+            [ row [ width (Element.minimum 300 fill) ] [ text "Unexpected JSON structure" ] ]
 
 
 makeErr : Validation.Error -> List (Element Msg)
@@ -509,16 +509,17 @@ taskList model =
         , column
             [ fillPortion 3 |> width
             , height fill
+            , width fill
             , spacing 10
             , padding 10
             ]
             (Maybe.withDefault
-                [ styledPrimaryText [] "👈 Choose a task on the left" ]
+                [ styledPrimaryText [ width fill ] "👈 Choose a task on the left" ]
                 (model.selectedTask
                     |> Maybe.map
                         (\selected ->
                             executionInput model.inputState model.formValues model.taskValidationErrors selected
-                                ++ [ row []
+                                ++ [ row [ width (Element.maximum 300 fill) ]
                                         [ submitButton (allowTaskSubmit model.activeSchema)
                                             model.formValues
                                             (toExecutionCreate selected.name selected.id model.formValues |> CreateExecution)

--- a/granary-ui/src/Styled.elm
+++ b/granary-ui/src/Styled.elm
@@ -15,6 +15,8 @@ import Element.Border as Border
 import Element.Font as Font
 import Element.Input as Input
 import Framework.Button as Button
+import Framework.Color
+import Html.Attributes exposing (disabled, style)
 
 
 primary : Element.Color
@@ -52,19 +54,35 @@ styledSecondaryText attrs s =
     el (Font.color secondary :: attrs) (text s)
 
 
-submitButton : (a -> Bool) -> a -> String -> msg -> Element.Element msg
-submitButton predicate value hint msg =
+submitButton : (a -> Bool) -> a -> msg -> Element.Element msg
+submitButton predicate value msg =
     let
         allowSubmit =
             predicate value
+
+        bgColor =
+            if allowSubmit then
+                accent
+
+            else
+                Framework.Color.lightGrey
     in
     Element.el
         []
         (Input.button
             (Button.simple
-                ++ [ Background.color accent
+                ++ [ Background.color bgColor
                    , Element.centerX
                    , Border.color primary
+                   , not allowSubmit |> disabled |> Element.htmlAttribute
+                   , (if allowSubmit then
+                        "pointer"
+
+                      else
+                        "not-allowed"
+                     )
+                        |> style "cursor"
+                        |> Element.htmlAttribute
                    ]
             )
             { onPress =
@@ -76,13 +94,7 @@ submitButton predicate value hint msg =
             , label = styledPrimaryText [] "Submit"
             }
         )
-        :: (if allowSubmit then
-                []
-
-            else
-                [ styledSecondaryText [] hint
-                ]
-           )
+        |> List.singleton
         |> column [ spacing 5 ]
 
 

--- a/granary-ui/src/Styled.elm
+++ b/granary-ui/src/Styled.elm
@@ -91,7 +91,17 @@ submitButton predicate value msg =
 
                 else
                     Nothing
-            , label = styledPrimaryText [] "Submit"
+            , label =
+                Element.el
+                    [ if allowSubmit then
+                        Font.color primary
+
+                      else
+                        Font.color <| rgb255 168 168 168
+                    ]
+                <|
+                    text
+                        "Submit"
             }
         )
         |> List.singleton

--- a/granary-ui/src/Styled.elm
+++ b/granary-ui/src/Styled.elm
@@ -1,0 +1,100 @@
+module Styled exposing
+    ( accent
+    , primary
+    , secondary
+    , secondaryShadow
+    , styledPrimaryText
+    , styledSecondaryText
+    , submitButton
+    , textInput
+    )
+
+import Element as Element exposing (column, el, rgb255, spacing, text)
+import Element.Background as Background
+import Element.Border as Border
+import Element.Font as Font
+import Element.Input as Input
+import Framework.Button as Button
+
+
+primary : Element.Color
+primary =
+    rgb255 75 59 64
+
+
+secondary : Element.Color
+secondary =
+    rgb255 246 141 17
+
+
+accent : Element.Color
+accent =
+    rgb255 253 233 135
+
+
+secondaryShadow : Element.Attr deco msg
+secondaryShadow =
+    Border.shadow
+        { offset = ( 0.1, 0.1 )
+        , size = 2
+        , blur = 3
+        , color = secondary
+        }
+
+
+styledPrimaryText : List (Element.Attribute msg) -> String -> Element.Element msg
+styledPrimaryText attrs s =
+    el (Font.color primary :: attrs) (text s)
+
+
+styledSecondaryText : List (Element.Attribute msg) -> String -> Element.Element msg
+styledSecondaryText attrs s =
+    el (Font.color secondary :: attrs) (text s)
+
+
+submitButton : (a -> Bool) -> a -> String -> msg -> Element.Element msg
+submitButton predicate value hint msg =
+    let
+        allowSubmit =
+            predicate value
+    in
+    Element.el
+        []
+        (Input.button
+            (Button.simple
+                ++ [ Background.color accent
+                   , Element.centerX
+                   , Border.color primary
+                   ]
+            )
+            { onPress =
+                if allowSubmit then
+                    Just msg
+
+                else
+                    Nothing
+            , label = styledPrimaryText [] "Submit"
+            }
+        )
+        :: (if allowSubmit then
+                []
+
+            else
+                [ styledSecondaryText [] hint
+                ]
+           )
+        |> column [ spacing 5 ]
+
+
+textInput : List (Element.Attribute msg) -> (String -> msg) -> Maybe String -> String -> String -> Element.Element msg
+textInput attrs f maybeText placeholder label =
+    Input.text
+        (Element.focused
+            [ secondaryShadow ]
+            :: attrs
+        )
+        { onChange = f
+        , text = maybeText |> Maybe.withDefault ""
+        , placeholder = Input.placeholder [] (text placeholder) |> Just
+        , label = Input.labelHidden label
+        }

--- a/granary-ui/src/Styled.elm
+++ b/granary-ui/src/Styled.elm
@@ -113,6 +113,7 @@ textInput attrs f maybeText placeholder label =
     Input.text
         (Element.focused
             [ secondaryShadow ]
+            :: spacing 3
             :: attrs
         )
         { onChange = f

--- a/granary-ui/src/Types.elm
+++ b/granary-ui/src/Types.elm
@@ -93,7 +93,7 @@ type Msg
     | TokenInput String
     | TokenSubmit
     | CreatedExecution (Result Http.Error GranaryExecution)
-    | TaskSelect GranaryTask
+    | NewExecutionForTask GranaryTask
     | ValidateWith
         { schema : Schema.SubSchema
         , fieldName : String

--- a/granary-ui/src/Types.elm
+++ b/granary-ui/src/Types.elm
@@ -75,7 +75,7 @@ type alias ExecutionCreate =
 
 type ExecutionCreateError
     = SchemaError (List Validation.Error)
-    | DecodingError JD.Error
+    | DecodingError String Int JD.Error
 
 
 type InputEvent
@@ -106,5 +106,5 @@ type Msg
     | AddTokenParam GranaryToken
     | GoHome
     | GotFiles File (List File)
-    | GeoJsonData String
+    | GeoJsonData String Int String
     | GeoJsonInputMouseInteraction InputEvent

--- a/granary-ui/src/Types.elm
+++ b/granary-ui/src/Types.elm
@@ -1,0 +1,91 @@
+module Types exposing
+    ( ExecutionCreate
+    , GranaryExecution
+    , GranaryTask
+    , GranaryToken
+    , Msg(..)
+    , PaginatedResponse
+    , StacAsset
+    )
+
+import Browser
+import Http as Http
+import Json.Decode as JD
+import Json.Schema.Definitions as Schema
+    exposing
+        ( Schema(..)
+        , SingleType(..)
+        , Type(..)
+        )
+import Time
+import Url
+import Uuid as Uuid
+
+
+type alias GranaryToken =
+    String
+
+
+type alias PaginatedResponse a =
+    { page : Int
+    , limit : Int
+    , results : List a
+    }
+
+
+type alias GranaryTask =
+    { id : Uuid.Uuid
+    , name : String
+    , validator : Schema
+    , jobDefinition : String
+    , jobQueue : String
+    }
+
+
+type alias StacAsset =
+    { href : String
+    , title : Maybe String
+    , description : Maybe String
+    , roles : List String
+    , mediaType : String
+    }
+
+
+type alias GranaryExecution =
+    { id : Uuid.Uuid
+    , taskId : Uuid.Uuid
+    , invokedAt : Time.Posix
+    , statusReason : Maybe String
+    , results : List StacAsset
+    , webhookId : Maybe Uuid.Uuid
+    , name : String
+    }
+
+
+type alias ExecutionCreate =
+    { name : String
+    , taskId : Uuid.Uuid
+    , arguments : JD.Value
+    }
+
+
+type Msg
+    = GotTasks (Result Http.Error (PaginatedResponse GranaryTask))
+    | GotExecutions (Maybe Uuid.Uuid) (Result Http.Error (PaginatedResponse GranaryExecution))
+    | Navigation Browser.UrlRequest
+    | UrlChanged Url.Url
+    | TokenInput String
+    | TokenSubmit
+    | CreatedExecution (Result Http.Error GranaryExecution)
+    | TaskSelect GranaryTask
+    | ValidateWith
+        { schema : Schema.SubSchema
+        , fieldName : String
+        , fieldValue : Result String JD.Value
+        }
+    | NameExecution String
+    | CreateExecution ExecutionCreate
+    | ToggleShowAssets Uuid.Uuid
+    | SearchExecutionName String
+    | AddTokenParam GranaryToken
+    | GoHome

--- a/granary-ui/src/Types.elm
+++ b/granary-ui/src/Types.elm
@@ -1,14 +1,17 @@
 module Types exposing
     ( ExecutionCreate
+    , ExecutionCreateError(..)
     , GranaryExecution
     , GranaryTask
     , GranaryToken
+    , InputEvent(..)
     , Msg(..)
     , PaginatedResponse
     , StacAsset
     )
 
 import Browser
+import File exposing (File)
 import Http as Http
 import Json.Decode as JD
 import Json.Schema.Definitions as Schema
@@ -17,6 +20,7 @@ import Json.Schema.Definitions as Schema
         , SingleType(..)
         , Type(..)
         )
+import Json.Schema.Validation as Validation
 import Time
 import Url
 import Uuid as Uuid
@@ -69,6 +73,18 @@ type alias ExecutionCreate =
     }
 
 
+type ExecutionCreateError
+    = SchemaError (List Validation.Error)
+    | DecodingError JD.Error
+
+
+type InputEvent
+    = Over
+    | Enter
+    | Leave
+    | Pick
+
+
 type Msg
     = GotTasks (Result Http.Error (PaginatedResponse GranaryTask))
     | GotExecutions (Maybe Uuid.Uuid) (Result Http.Error (PaginatedResponse GranaryExecution))
@@ -89,3 +105,6 @@ type Msg
     | SearchExecutionName String
     | AddTokenParam GranaryToken
     | GoHome
+    | GotFiles File (List File)
+    | GeoJsonData String
+    | GeoJsonInputMouseInteraction InputEvent

--- a/granary-ui/src/Urls.elm
+++ b/granary-ui/src/Urls.elm
@@ -1,0 +1,35 @@
+module Urls exposing (apiExecutionsUrl, executionsUrl)
+
+import Uuid as Uuid
+
+
+apiExecutionsUrl : Maybe String -> Maybe Uuid.Uuid -> String
+apiExecutionsUrl namesLike taskId =
+    "/api" ++ executionsUrl namesLike taskId
+
+
+executionsUrl : Maybe String -> Maybe Uuid.Uuid -> String
+executionsUrl namesLike taskId =
+    let
+        baseUrl =
+            "/executions"
+
+        taskSearch =
+            taskId
+                |> Maybe.map ((++) "taskId=" << Uuid.toString)
+
+        nameSearch =
+            namesLike
+                |> Maybe.map ((++) "name=")
+
+        qp =
+            [ taskSearch, nameSearch ]
+                |> List.filterMap identity
+                |> List.intersperse "&"
+                |> String.concat
+    in
+    if String.isEmpty qp then
+        baseUrl
+
+    else
+        baseUrl ++ "?" ++ qp


### PR DESCRIPTION
## Overview

This PR adds a drag and drop + file selector file input for geojson.

Things that would probably be nice to have:

- an `x` to get rid of what you've chosen
- better errors about what's wrong if you upload `{"a": 3}` instead of an actual geojson

But they're not there. We can decide what would be nice to have while mobbing.

It also disables buttons instead of showing a hint (hi Alex). It also removes the feature flag thing from the PR template. It also separates the pages into modules so we can spend less time talking about file size while mobbing.

### Checklist

0 checklist items apply 🤷‍♂️ 

### Notes

Arguably login could also be moved to a module? I don't know. I feel like login as the top level view makes sense for the empty model case, which is what `Main.elm` starts with, so I like it where it is.

## Testing Instructions

- `./scripts/update --frontend`
- `docker-compose up -d database`
- navigate to `localhost:8080`
- enter a token from your database
- choose the Rasterio Water Mask model
- drag a random file onto the drop zone. It will show a nice orange border when you're in the right place.
- it should be mad at you about the file you uploaded
- drag a real geojson file onto the drop zone
- it should accept the file
- fill in the rest of the parameters with whatever you want and submit
- the API should also accept the geojson

Closes #394 
