### PR TITLE
set logo size correctly

### DIFF
--- a/api/src/main/resources/assets/index.html
+++ b/api/src/main/resources/assets/index.html
@@ -19286,19 +19286,23 @@ var $mdgriffith$elm_ui$Element$image = F2(
 	});
 var $author$project$Main$logo = F2(
 	function (attrs, maxSize) {
+		var setMax = function (f) {
+			return f(
+				A2(
+					$mdgriffith$elm_ui$Element$maximum,
+					maxSize,
+					A2(
+						$mdgriffith$elm_ui$Element$minimum,
+						100,
+						$mdgriffith$elm_ui$Element$fillPortion(1))));
+		};
 		return A2(
 			$mdgriffith$elm_ui$Element$image,
 			_Utils_ap(
 				_List_fromArray(
 					[
-						$mdgriffith$elm_ui$Element$height(
-						A2(
-							$mdgriffith$elm_ui$Element$maximum,
-							maxSize,
-							A2(
-								$mdgriffith$elm_ui$Element$minimum,
-								100,
-								$mdgriffith$elm_ui$Element$fillPortion(1)))),
+						setMax($mdgriffith$elm_ui$Element$width),
+						setMax($mdgriffith$elm_ui$Element$height),
 						$mdgriffith$elm_ui$Element$padding(10)
 					]),
 				attrs),
@@ -19388,16 +19392,7 @@ var $author$project$Main$loginPage = function (model) {
 			]),
 		_List_fromArray(
 			[
-				A2(
-				$mdgriffith$elm_ui$Element$row,
-				_List_fromArray(
-					[
-						$mdgriffith$elm_ui$Element$width($mdgriffith$elm_ui$Element$fill)
-					]),
-				_List_fromArray(
-					[
-						A2($author$project$Main$logo, _List_Nil, 200)
-					])),
+				A2($author$project$Main$logo, _List_Nil, 400),
 				A2(
 				$mdgriffith$elm_ui$Element$row,
 				_List_fromArray(

--- a/api/src/main/scala/com/rasterfoundry/granary/Server.scala
+++ b/api/src/main/scala/com/rasterfoundry/granary/Server.scala
@@ -113,7 +113,7 @@ object ApiServer extends IOApp {
         Options.paginationConfig
       ).tupled
     }
-    cmd.parse(args) map {
+    cmd.parse(args, env = sys.env) map {
       case (dbConfig, metaConfig, s3Config, authConfig, paginationConfig) =>
         createServer(dbConfig, metaConfig, s3Config, authConfig, paginationConfig)
           .use(_ => IO.never)

--- a/granary-ui/src/Main.elm
+++ b/granary-ui/src/Main.elm
@@ -611,8 +611,13 @@ update msg model =
 
 logo : List (Element.Attribute msg) -> Int -> Element msg
 logo attrs maxSize =
+    let
+        setMax f =
+            fillPortion 1 |> Element.minimum 100 |> Element.maximum maxSize |> f
+    in
     Element.image
-        ([ fillPortion 1 |> Element.minimum 100 |> Element.maximum maxSize |> height
+        ([ setMax width
+         , setMax height
          , padding 10
          ]
             ++ attrs
@@ -645,8 +650,13 @@ homeLink =
 
 loginPage : Model -> Element Msg
 loginPage model =
-    column [ spacing 24, Element.centerX, Element.centerY, width Element.shrink ]
-        [ row [ width fill ] [ logo [] 200 ]
+    column
+        [ spacing 24
+        , Element.centerX
+        , Element.centerY
+        , width Element.shrink
+        ]
+        [ logo [] 400
         , row [ width fill, spacing 8 ]
             [ textInput [] TokenInput model.secretsUnsubmitted "Enter a token" "Token input"
             , submitButton (not << String.isEmpty)


### PR DESCRIPTION
## Overview

This PR makes it so that the logo doesn't accidentally become invisible. It also sets the environment to `sys.env`, since:

- it helped decline figure out how to fall back in https://github.com/azavea/franklin/pull/398
- it's necessary to avoid falling back to localhost when filling in the API host at server startup -- see the error in [these cloudwatch logs](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Fbatch$252Fjob/log-events/cloud-buster$252Fdefault$252F6ffb07dd-3b9c-4b47-aac9-43a63e04c1b4), for example

### Checklist

🤷‍♂️

### Notes

I was able to reproduce the vanishing logo in Edge and Chrome, and on localhost it's visible in both of them. I don't know what browser the problem was originally reported from, but also Firefox still works for me.

## Testing Instructions

- `./scripts/update --frontend`
- `./sbt bloopInstall` if you haven't for a sec (big cats changes)
- `docker-compose up -d database`
- `AWS_PROFILE=raster-foundry AWS_REGION=us-east-1 ./scripts/server`
- navigate to `localhost:8080`, enter a token, and view executions in Chrome and Firefox (and also Edge if you have it)
- confirm we have GRANARY_API_HOST set in the task definition for the Granary API

Closes #414 
