### PR TITLE
Add tags to executions

### DIFF
--- a/api/src/main/scala/com/rasterfoundry/granary/endpoints/ExecutionEndpoints.scala
+++ b/api/src/main/scala/com/rasterfoundry/granary/endpoints/ExecutionEndpoints.scala
@@ -3,8 +3,10 @@ package com.rasterfoundry.granary.api.endpoints
 import com.rasterfoundry.granary.api._
 import com.rasterfoundry.granary.api.error._
 import com.rasterfoundry.granary.datamodel._
+import eu.timepit.refined.types.string.NonEmptyString
 import sttp.tapir.{ValidationError => _, _}
 import sttp.tapir.json.circe._
+import sttp.tapir.codec.refined._
 
 import java.util.UUID
 
@@ -54,6 +56,7 @@ object ExecutionEndpoints {
       .in(query[Option[UUID]]("taskId"))
       .in(query[Option[JobStatus]]("status"))
       .in(query[Option[String]]("name"))
+      .in(query[Option[List[NonEmptyString]]]("tags"))
       .out(jsonBody[PaginatedResponse[Execution]])
       .errorOut(
         oneOf[CrudError](

--- a/api/src/main/scala/com/rasterfoundry/granary/endpoints/package.scala
+++ b/api/src/main/scala/com/rasterfoundry/granary/endpoints/package.scala
@@ -13,14 +13,16 @@ package object endpoints {
     Codec.string.mapDecode(s => DecodeResult.Value(TokenHeader(s)))(_.headerValue)
 
   implicit val listNonEmptyStringCodec: Codec[String, List[NonEmptyString], TextPlain] =
-    Codec.string.mapDecode(commaSepString =>
-      DecodeResult.fromOption(
-        commaSepString
-          .split(",")
-          .toList
-          .traverse({ s =>
-            NonEmptyString.from(s).toOption
-          })
-      )
-    )(_.toList.mkString(","))
+    Codec.string.mapDecode({
+      case "" => DecodeResult.Value(Nil)
+      case commaSepString =>
+        DecodeResult.fromOption(
+          commaSepString
+            .split(",")
+            .toList
+            .traverse({ s =>
+              NonEmptyString.from(s).toOption
+            })
+        )
+    })(_.toList.mkString(","))
 }

--- a/api/src/main/scala/com/rasterfoundry/granary/services/TaskService.scala
+++ b/api/src/main/scala/com/rasterfoundry/granary/services/TaskService.scala
@@ -64,29 +64,29 @@ class TaskService[F[_]: Sync](
 
   val create = TaskEndpoints.create
     .serverLogicPart(auth.fallbackToForbidden)
-    .andThen({
-      case (token, rest) => createTask(token, rest)
+    .andThen({ case (token, rest) =>
+      createTask(token, rest)
     })
     .toRoutes
 
   val list = TaskEndpoints.list
     .serverLogicPart(auth.fallbackToForbidden)
-    .andThen({
-      case (token, rest) => listTasks(token, rest)
+    .andThen({ case (token, rest) =>
+      listTasks(token, rest)
     })
     .toRoutes
 
   val detail = TaskEndpoints.idLookup
     .serverLogicPart(auth.fallbackToForbidden)
-    .andThen({
-      case (token, rest) => getById(token, rest)
+    .andThen({ case (token, rest) =>
+      getById(token, rest)
     })
     .toRoutes
 
   val delete = TaskEndpoints.delete
     .serverLogicPart(auth.fallbackToForbidden)
-    .andThen({
-      case (token, rest) => deleteById(token, rest)
+    .andThen({ case (token, rest) =>
+      deleteById(token, rest)
     })
     .toRoutes
 

--- a/api/src/test/scala/com/rasterfoundry/granary/ExecutionServiceSpec.scala
+++ b/api/src/test/scala/com/rasterfoundry/granary/ExecutionServiceSpec.scala
@@ -168,7 +168,10 @@ class ExecutionServiceSpec
             allCreatedPreds <- executions traverse { createExecution(_, executionService) }
             task1Uri = Uri.fromString(s"/executions?taskId=${createdTask1.id}").right.get
             task2Uri = Uri.fromString(s"/executions?taskId=${createdTask2.id}").right.get
-            find1Uri = Uri.fromString(s"/executions?tags=${execution1.tags.mkString(",")}").right.get
+            find1Uri = Uri
+              .fromString(s"/executions?tags=${execution1.tags.mkString(",")}")
+              .right
+              .get
             findNothingUri = Uri.fromString(s"/executions?tags=not-present-in-any-tags").right.get
             listedForTask1 <- executionService.routes.run(
               Request[IO](method = Method.GET, uri = task1Uri)

--- a/api/src/test/scala/com/rasterfoundry/granary/ExecutionServiceSpec.scala
+++ b/api/src/test/scala/com/rasterfoundry/granary/ExecutionServiceSpec.scala
@@ -161,13 +161,17 @@ class ExecutionServiceSpec
           val testIO = for {
             createdTask1 <- createTask(task1, taskService)
             createdTask2 <- createTask(task2, taskService)
-            executions = List(
+            createdExecution1 <- createExecution(
               execution1.copy(taskId = createdTask1.id),
-              execution2.copy(taskId = createdTask2.id)
+              executionService
             )
-            allCreatedPreds <- executions traverse { createExecution(_, executionService) }
-            task1Uri = Uri.fromString(s"/executions?taskId=${createdTask1.id}").right.get
-            task2Uri = Uri.fromString(s"/executions?taskId=${createdTask2.id}").right.get
+            createdExecution2 <- createExecution(
+              execution2.copy(taskId = createdTask2.id),
+              executionService
+            )
+            allCreatedPreds = List(createdExecution1, createdExecution2)
+            task1Uri        = Uri.fromString(s"/executions?taskId=${createdTask1.id}").right.get
+            task2Uri        = Uri.fromString(s"/executions?taskId=${createdTask2.id}").right.get
             find1Uri = Uri
               .fromString(s"/executions?tags=${execution1.tags.mkString(",")}")
               .right
@@ -209,6 +213,7 @@ class ExecutionServiceSpec
             (
               createdTask1.id,
               createdTask2.id,
+              createdExecution1,
               listedForTask1,
               listedForTask2,
               listedForTags,
@@ -222,6 +227,7 @@ class ExecutionServiceSpec
           val (
             task1Id,
             task2Id,
+            createdExecution1,
             task1Preds,
             task2Preds,
             listedTags1,
@@ -242,7 +248,7 @@ class ExecutionServiceSpec
           }) && (failureResults.results map {
             _.status
           }) ==== (failureResults.results map { _ => JobStatus.Failed }) && (
-            listedTags1.results.map(_.id).contains(task1Id)
+            listedTags1.results.map(_.id).contains(createdExecution1.id)
           ) && findNothing.results.isEmpty
         }
     }

--- a/api/src/test/scala/com/rasterfoundry/granary/ExecutionServiceSpec.scala
+++ b/api/src/test/scala/com/rasterfoundry/granary/ExecutionServiceSpec.scala
@@ -181,9 +181,8 @@ class ExecutionServiceSpec
                 )
               ),
               ExecutionFailure("wasn't set up to succeed")
-            ).zip(allCreatedPreds) traverse {
-              case (msg, execution) =>
-                updateExecution[Execution](msg, execution, execution.webhookId.get)
+            ).zip(allCreatedPreds) traverse { case (msg, execution) =>
+              updateExecution[Execution](msg, execution, execution.webhookId.get)
             }
             successUri = Uri.fromString(s"/executions?status=successful").right.get
             failureUri = Uri.fromString(s"/executions?status=failed").right.get

--- a/build.sbt
+++ b/build.sbt
@@ -55,6 +55,7 @@ lazy val datamodelDependencies = commonDependencies ++ Seq(
   Dependencies.circeJsonSchema,
   Dependencies.newtype,
   Dependencies.refined,
+  Dependencies.refinedScalacheck % "test",
   Dependencies.shapeless,
   Dependencies.stac4s,
   Dependencies.scalacheck

--- a/build.sbt
+++ b/build.sbt
@@ -53,6 +53,7 @@ lazy val datamodelDependencies = commonDependencies ++ Seq(
   Dependencies.circeCore,
   Dependencies.circeGeneric,
   Dependencies.circeJsonSchema,
+  Dependencies.circeRefined,
   Dependencies.newtype,
   Dependencies.refined,
   Dependencies.refinedScalacheck % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,6 @@ lazy val datamodelDependencies = commonDependencies ++ Seq(
   Dependencies.circeRefined,
   Dependencies.newtype,
   Dependencies.refined,
-  Dependencies.refinedScalacheck % "test",
   Dependencies.shapeless,
   Dependencies.stac4s,
   Dependencies.scalacheck

--- a/database/src/main/resources/migrations/V13__add_tags_to_executions.sql
+++ b/database/src/main/resources/migrations/V13__add_tags_to_executions.sql
@@ -1,1 +1,3 @@
 ALTER TABLE executions ADD COLUMN tags text [] NOT NULL default '{}';
+
+CREATE INDEX executions_tags_idx ON executions(tags);

--- a/database/src/main/resources/migrations/V13__add_tags_to_executions.sql
+++ b/database/src/main/resources/migrations/V13__add_tags_to_executions.sql
@@ -1,0 +1,1 @@
+ALTER TABLE executions ADD COLUMN tags text [] NOT NULL default '{}';

--- a/database/src/main/scala/com/rasterfoundry/granary/ExecutionDao.scala
+++ b/database/src/main/scala/com/rasterfoundry/granary/ExecutionDao.scala
@@ -59,7 +59,7 @@ object ExecutionDao {
           Fragment.const(s"name like '%$s%'")
         },
         tags.toNel map { _ =>
-            fr"""tags @> $tags :: text[]"""
+          fr"""tags @> $tags :: text[]"""
         }
       ),
       pageRequest

--- a/database/src/main/scala/com/rasterfoundry/granary/ExecutionDao.scala
+++ b/database/src/main/scala/com/rasterfoundry/granary/ExecutionDao.scala
@@ -135,7 +135,8 @@ object ExecutionDao {
             "results",
             "webhook_id",
             "owner",
-            "name"
+            "name",
+            "tags"
           ) map { Right(_) }
       }
     }
@@ -173,6 +174,7 @@ object ExecutionDao {
         (uuid_generate_v4(), ${execution.taskId}, now(), ${execution.arguments},
         'CREATED', NULL, '[]' :: jsonb, uuid_generate_v4(), $owner, ${execution.name}, ${execution.tags})
     """
+    println(s"Fragment is: $fragment")
     val insertIO: OptionT[ConnectionIO, Either[ExecutionDaoError, Execution]] = for {
       task <- OptionT { TaskDao.getTask(token, execution.taskId) }
       argCheck = task.validator.validate(execution.arguments)

--- a/database/src/main/scala/com/rasterfoundry/granary/TokenDao.scala
+++ b/database/src/main/scala/com/rasterfoundry/granary/TokenDao.scala
@@ -28,7 +28,7 @@ object TokenDao {
     (for {
       uuid <- LiftIO[ConnectionIO].liftIO(IO { UUID.fromString(tokenId) })
       validated <- (
-          selectF ++ Fragments.whereAnd(fr"id = $uuid")
+        selectF ++ Fragments.whereAnd(fr"id = $uuid")
       ).query[Token].option
     } yield validated) handleErrorWith { e =>
       LiftIO[ConnectionIO].liftIO {

--- a/database/src/main/scala/com/rasterfoundry/granary/package.scala
+++ b/database/src/main/scala/com/rasterfoundry/granary/package.scala
@@ -3,9 +3,11 @@ package com.rasterfoundry.granary
 import com.rasterfoundry.granary.database.meta.{CirceJsonbMeta, EnumMeta}
 import com.rasterfoundry.granary.datamodel._
 
+import cats.syntax.traverse._
 import doobie._
 import doobie.implicits._
 import doobie.postgres.implicits._
+import eu.timepit.refined.types.string.NonEmptyString
 import io.estatico.newtype.Coercible
 
 package object database extends CirceJsonbMeta with EnumMeta {
@@ -26,4 +28,14 @@ package object database extends CirceJsonbMeta with EnumMeta {
     tokenToUserId(token) map { userId =>
       fr"owner = $userId"
     }
+
+  implicit val getListNonEmptyString: Get[List[NonEmptyString]] =
+    Get[List[String]].temap({ strings =>
+      strings traverse { s =>
+        NonEmptyString.from(s)
+      }
+    })
+
+  implicit val putListNonEmptyString: Put[List[NonEmptyString]] =
+    Put[List[String]].contramap(_.toList.map(_.value))
 }

--- a/datamodel/src/main/scala/com/rasterfoundry/granary/Execution.scala
+++ b/datamodel/src/main/scala/com/rasterfoundry/granary/Execution.scala
@@ -55,11 +55,14 @@ object Execution {
 
   object Create {
     implicit val encCreate: Encoder[Create] = deriveEncoder
+
     implicit val decCreate: Decoder[Create] = Decoder.forProduct4(
-      "name", "taskId", "arguments", "tags"
-      )((name: String, taskId: UUID, arguments: Json, tags: Option[List[NonEmptyString]]) =>
-        Create(name, taskId, arguments, tags getOrElse Nil
-        )
-      )
+      "name",
+      "taskId",
+      "arguments",
+      "tags"
+    )((name: String, taskId: UUID, arguments: Json, tags: Option[List[NonEmptyString]]) =>
+      Create(name, taskId, arguments, tags getOrElse Nil)
+    )
   }
 }

--- a/datamodel/src/main/scala/com/rasterfoundry/granary/Execution.scala
+++ b/datamodel/src/main/scala/com/rasterfoundry/granary/Execution.scala
@@ -2,8 +2,10 @@ package com.rasterfoundry.granary.datamodel
 
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3URI}
 import com.azavea.stac4s.StacItemAsset
+import eu.timepit.refined.types.string.NonEmptyString
 import io.circe._
 import io.circe.generic.semiauto._
+import io.circe.refined._
 
 import scala.util.Try
 
@@ -20,7 +22,8 @@ case class Execution(
     results: List[StacItemAsset],
     webhookId: Option[UUID],
     owner: Option[UUID],
-    name: String
+    name: String,
+    tags: List[NonEmptyString]
 ) {
 
   def signS3OutputLocation(s3Client: AmazonS3): Execution = {
@@ -46,7 +49,8 @@ object Execution {
   case class Create(
       name: String,
       taskId: UUID,
-      arguments: Json
+      arguments: Json,
+      tags: List[NonEmptyString] = List.empty
   )
 
   object Create {

--- a/datamodel/src/main/scala/com/rasterfoundry/granary/Execution.scala
+++ b/datamodel/src/main/scala/com/rasterfoundry/granary/Execution.scala
@@ -55,6 +55,11 @@ object Execution {
 
   object Create {
     implicit val encCreate: Encoder[Create] = deriveEncoder
-    implicit val decCreate: Decoder[Create] = deriveDecoder
+    implicit val decCreate: Decoder[Create] = Decoder.forProduct4(
+      "name", "taskId", "arguments", "tags"
+      )((name: String, taskId: UUID, arguments: Json, tags: Option[List[NonEmptyString]]) =>
+        Create(name, taskId, arguments, tags getOrElse Nil
+        )
+      )
   }
 }

--- a/datamodel/src/test/scala/com/rasterfoundry/granary/Generators.scala
+++ b/datamodel/src/test/scala/com/rasterfoundry/granary/Generators.scala
@@ -1,6 +1,8 @@
 package com.rasterfoundry.granary.datamodel
 
 import cats.syntax.apply._
+import eu.timepit.refined.scalacheck.string._
+import eu.timepit.refined.types.string.NonEmptyString
 import io.circe.syntax._
 import org.scalacheck._
 import org.scalacheck.cats.implicits._
@@ -25,7 +27,8 @@ trait Generators {
     (
       shortStringGen,
       Gen.delay(UUID.randomUUID),
-      Gen.const(Map.empty[String, String].asJson)
+      Gen.const(Map.empty[String, String].asJson),
+      Gen.listOf(Arbitrary.arbitrary[NonEmptyString])
     ).tupled map {
       Function.tupled(Execution.Create.apply)
     }

--- a/datamodel/src/test/scala/com/rasterfoundry/granary/Generators.scala
+++ b/datamodel/src/test/scala/com/rasterfoundry/granary/Generators.scala
@@ -1,7 +1,6 @@
 package com.rasterfoundry.granary.datamodel
 
 import cats.syntax.apply._
-import eu.timepit.refined.scalacheck.string._
 import eu.timepit.refined.types.string.NonEmptyString
 import io.circe.syntax._
 import org.scalacheck._
@@ -28,7 +27,9 @@ trait Generators {
       shortStringGen,
       Gen.delay(UUID.randomUUID),
       Gen.const(Map.empty[String, String].asJson),
-      Gen.listOf(Arbitrary.arbitrary[NonEmptyString])
+      Gen.choose(0, 20) flatMap { listLength =>
+        Gen.listOfN(listLength, shortStringGen map { NonEmptyString.unsafeFrom })
+      }
     ).tupled map {
       Function.tupled(Execution.Create.apply)
     }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -78,7 +78,6 @@ object Dependencies {
   val pureConfigGeneric   = "com.github.pureconfig"       %% "pureconfig-generic"    % Versions.PureConfig
   val refined             = "eu.timepit"                  %% "refined"               % Versions.RefinedVersion
   val refinedPureconfig   = "eu.timepit"                  %% "refined-pureconfig"    % Versions.RefinedVersion
-  val refinedScalacheck   = "eu.timepit"                  %% "refined-scalacheck"    % Versions.RefinedVersion
   val scalacheck          = "org.scalacheck"              %% "scalacheck"            % Versions.ScalacheckVersion % "test"
   val shapeless           = "com.chuusai"                 %% "shapeless"             % Versions.ShapelessVersion
   val slf4jApi            = "org.slf4j"                    % "slf4j-api"             % Versions.Slf4jVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -78,6 +78,7 @@ object Dependencies {
   val pureConfigGeneric   = "com.github.pureconfig"       %% "pureconfig-generic"    % Versions.PureConfig
   val refined             = "eu.timepit"                  %% "refined"               % Versions.RefinedVersion
   val refinedPureconfig   = "eu.timepit"                  %% "refined-pureconfig"    % Versions.RefinedVersion
+  val refinedScalacheck   = "eu.timepit"                  %% "refined-scalacheck"    % Versions.RefinedVersion
   val scalacheck          = "org.scalacheck"              %% "scalacheck"            % Versions.ScalacheckVersion % "test"
   val shapeless           = "com.chuusai"                 %% "shapeless"             % Versions.ShapelessVersion
   val slf4jApi            = "org.slf4j"                    % "slf4j-api"             % Versions.Slf4jVersion


### PR DESCRIPTION
## Overview

This PR adds tags to executions. A `tags` key isn't required on POST so that we don't have to change the granary ui interaction. You can also search for executions with a set of tags.

### Checklist

- [x] New tables and queries have appropriate indices added
- [x] Any new migrations have been audited to make sure they won't kill the application while being applied
- [x] Any new API endpoints have tests

## Testing Instructions

- `./scripts/migrate migrate`
- `./sbt bloopInstall`
- `AWS_PROFILE=raster-foundry AWS_REGION=us-east-1 ./scripts/server`
- navigate to `localhost:8080`, supply the token from the dev database, and create an execution with the network tab open for "silly task"
- create another one
- for the first one, `update executions set tags = '{ "foo", "bar" }' where id = '<the execution id>'` -- you can get the execution id from the api response
- `export JWT_AUTH_TOKEN=<the dev token>`
- `http --auth-type=jwt :8080/api/executions tags=="foo,bar"` -- you should see the execution you tagged
- `http --auth-type=jwt :8080/api/executions tags=="bogus,foo,bar"` -- you should see nothing
- `http --auth-type=jwt :8080/api/executions` -- you should see both executions

Closes #428 